### PR TITLE
Add README, hide how-to-doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm run start
 ```
 
 You will now be able visit the locally served website at
-[localhost:3000](localhost:3000)
+[http://localhost:3000](http://localhost:3000)
 
 ## How can I contribute?
 
@@ -43,12 +43,12 @@ npm install
 npm run dev
 ```
 
-The website will be available at [localhost:3000](localhost:3000) and the
-changes you make to the project will be reflected there instantaneously.
+The website will be available at [http://localhost:3000](http://localhost:3000)
+and the changes you make to the project will be reflected there instantaneously.
 
 There's a hidden "How to doc" section that'll teach you how to write new
 entries. You can make this section visible by visiting
-[localhost:3000/how-to-doc](localhost:3000/how-to-doc) or with the
+[http://localhost:3000/how-to-doc](http://localhost:3000/how-to-doc) or with the
 <kbd>CTRL</kbd> + <kbd>.</kbd> (control plus period) keyboard shortcut.
 
 After committing your changes to a new branch, push it to this repo and open a

--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# docs
+# The CosmWasm documentation platform
+
+## What is it?
+
+A documentation-focused website for all CosmWasm-related technologies.
+
+No matter if you need to integrate CosmWasm with a chain, create some smart
+contracts, or just have a look around to see what CosmWasm is about, here you'll
+be able to learn about CosmWasm's core, wasmd, storage, testing, IBC,
+CosmJS/InterchainJS, Sylvia framework, etc.
+
+## Where is it?
+
+The website is hosted at
+[https://cosmwasm-docs.vercel.app](https://cosmwasm-docs.vercel.app/).
+
+## How is it made?
+
+The deployed documentation is a [Nextra](https://nextra.site) project configured
+with the `nextra-theme-docs` package.
+
+## How can I run it locally?
+
+You can just clone this repo and run the following commands, after making sure
+you use node `v20`:
+
+```shell
+npm install
+npm run build
+npm run start
+```
+
+You will now be able visit the locally served website at
+[localhost:3000](localhost:3000)
+
+## How can I contribute?
+
+After cloning this repo, make sure you use node `v20` before running these
+commands:
+
+```shell
+npm install
+npm run dev
+```
+
+The website will be available at [localhost:3000](localhost:3000) and the
+changes you make to the project will be reflected there instantaneously.
+
+There's a hidden "How to doc" section that'll teach you how to write new
+entries. You can make this section visible by visiting
+[localhost:3000/how-to-doc](localhost:3000/how-to-doc) or with the
+<kbd>CTRL</kbd> + <kbd>.</kbd> (control plus period) keyboard shortcut.
+
+After committing your changes to a new branch, push it to this repo and open a
+PR. This will automatically generate a Vercel preview link for the reviewers to
+check.

--- a/src/components/TagDots.jsx
+++ b/src/components/TagDots.jsx
@@ -5,11 +5,12 @@ export default function TagDots({ route }) {
 
   return tags?.length ? (
     <div className="nx-inline-flex nx-gap-1 tag-dots">
-      {tags.map((t) => (
+      {tags.map((tag) => (
         <span
+          key={tag}
           className="nx-rounded-full"
           style={{
-            backgroundColor: tagsObj.colors[t],
+            backgroundColor: tagsObj.colors[tag],
             width: "8px",
             height: "8px",
           }}

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,0 +1,20 @@
+import { useCallback, useEffect } from "react";
+import "./global.css";
+
+export default function App({ Component, pageProps }) {
+  const goToDocs = useCallback((event) => {
+    if (event.ctrlKey && event.key === ".") {
+      window.location.href = "/how-to-doc";
+      event.preventDefault();
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("keyup", goToDocs);
+    return () => {
+      window.removeEventListener("keyup", goToDocs);
+    };
+  }, [goToDocs]);
+
+  return <Component {...pageProps} />;
+}

--- a/src/pages/_app.mdx
+++ b/src/pages/_app.mdx
@@ -1,5 +1,0 @@
-import "./global.css";
-
-export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
-}

--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -1,4 +1,4 @@
 {
   "index": "Welcome",
-  "how-to-doc": "How to Doc"
+  "how-to-doc": "How to doc"
 }

--- a/src/pages/global.css
+++ b/src/pages/global.css
@@ -1,3 +1,8 @@
-button .tag-dots {
+/* Hide TagDots for directories on the sidebar */
+button .tag-dots,
+/* Hide How to Doc directory on the sidebar */
+li:has(button > .how-to-doc-dir),
+/* Hide links to How to Doc index, except the prevLink on the page after that */
+a[href="/how-to-doc"]:not(:has(div))[class~="ltr:nx-ml-auto"] {
   display: none;
 }

--- a/src/pages/how-to-doc/_meta.json
+++ b/src/pages/how-to-doc/_meta.json
@@ -1,6 +1,7 @@
 {
   "index": "Introduction",
   "mdx": "MDX",
+  "tags": "Tags",
   "callout": "Callout",
   "tabs": "Tabs"
 }

--- a/src/pages/how-to-doc/index.mdx
+++ b/src/pages/how-to-doc/index.mdx
@@ -8,4 +8,18 @@ import Tags from "@/components/Tags";
 
 # How to doc
 
-The next articles will teach you how to write MDX files for documentation.
+The next articles will teach you the basics for writing documentation using
+[Nextra](https://nextra.site/):
+
+- [MDX](/how-to-doc/mdx): general MDX syntax and how to use it in Nextra.
+- [Tags](/how-to-doc/tags): how to assign tags per file for extra grouping.
+- [Callout](/how-to-doc/callout): how to use the Callout component for
+  attracting attention.
+- [Tabs](/how-to-doc/tabs): a Tabs component for switching between related
+  content.
+
+Please use the `.mdx` extension for the documentation files, so that tags can be
+properly generated and you can use React components inside.
+
+You can also check out Nextra's [official docs](https://nextra.site/docs) for
+more information.

--- a/src/pages/how-to-doc/tags.mdx
+++ b/src/pages/how-to-doc/tags.mdx
@@ -1,0 +1,48 @@
+---
+tags: ["tutorial", "component"]
+---
+
+# Tags
+
+A [front matter](https://github.com/jxson/front-matter) attribute allows us to
+define tags per file and a custom React component shows them as pills on the
+website.
+
+## Example
+
+import Tags from "@/components/Tags";
+
+<Tags />
+
+## Usage
+
+```mdx filename="tags.mdx"
+---
+tags: ["tutorial", "component"]
+---
+
+import Tags from "@/components/Tags";
+
+<Tags />
+
+# My new article
+
+This is an example article with tags.
+```
+
+Please use array syntax for the front matter tags even if it's only a single
+tag:
+
+```mdx filename="single-tag.mdx"
+---
+tags: ["my-tag"]
+---
+
+import Tags from "@/components/Tags";
+
+<Tags />
+
+# My newest article
+
+This is an example article with a single tag.
+```

--- a/src/theme.config.js
+++ b/src/theme.config.js
@@ -31,11 +31,11 @@ export default {
             y2="653.676"
             gradientUnits="userSpaceOnUse"
           >
-            <stop stop-color="#FCECB2" />
-            <stop offset=".26" stop-color="#FF8B89" />
-            <stop offset=".521" stop-color="#FC8ADC" />
-            <stop offset=".755" stop-color="#7954FF" />
-            <stop offset="1" stop-color="#70BCFF" />
+            <stop stopColor="#FCECB2" />
+            <stop offset=".26" stopColor="#FF8B89" />
+            <stop offset=".521" stopColor="#FC8ADC" />
+            <stop offset=".755" stopColor="#7954FF" />
+            <stop offset="1" stopColor="#70BCFF" />
           </linearGradient>
         </defs>
       </svg>

--- a/src/theme.config.js
+++ b/src/theme.config.js
@@ -1,6 +1,7 @@
 import TagDots from "@/components/TagDots";
 import { iceland } from "@/utils/fonts";
 import { useConfig } from "nextra-theme-docs";
+import { useEffect, useState } from "react";
 
 /**
  * @type {import('nextra-theme-docs').DocsThemeConfig}
@@ -68,8 +69,18 @@ export default {
   },
   sidebar: {
     titleComponent: ({ title, route }) => {
+      const [isDocRoute, setIsDocRoute] = useState(false);
+
+      useEffect(() => {
+        setIsDocRoute(window.location.pathname.startsWith("/how-to-doc"));
+      }, []);
+
       return (
-        <div className>
+        <div
+          className={
+            !isDocRoute && title === "How to doc" ? "how-to-doc-dir" : ""
+          }
+        >
           <span>{title}</span> <TagDots route={route} />
         </div>
       );


### PR DESCRIPTION
- Adds README.
- Hides the "How to doc" section when not inside it.
- Adds keyboard shortcut for accesing it.
- Fixes rendering TagDots on sidebar directories instead of just files.