### PR TITLE
Rename _app to mdx

### DIFF
--- a/src/components/DocShortcut.jsx
+++ b/src/components/DocShortcut.jsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect } from "react";
-import "./global.css";
 
-export default function App({ Component, pageProps }) {
+export default function DocShortcut() {
   const goToDocs = useCallback((event) => {
     if (event.ctrlKey && event.key === ".") {
       window.location.href = "/how-to-doc";
@@ -16,5 +15,5 @@ export default function App({ Component, pageProps }) {
     };
   }, [goToDocs]);
 
-  return <Component {...pageProps} />;
+  return null;
 }

--- a/src/pages/_app.mdx
+++ b/src/pages/_app.mdx
@@ -1,0 +1,11 @@
+import DocShortcut from "@/components/DocShortcut";
+import "./global.css";
+
+export default function App({ Component, pageProps }) {
+  return (
+    <>
+      <DocShortcut />
+      <Component {...pageProps} />
+    </>
+  );
+}


### PR DESCRIPTION
Get rid of build warning by making _app.jsx an mdx again. Logic extracted to DocShortcut.jsx