### PR TITLE
Simplify tags usage

### DIFF
--- a/scripts/gen-tags.mjs
+++ b/scripts/gen-tags.mjs
@@ -1,58 +1,84 @@
 import { promises as fs } from "fs";
 import matter from "gray-matter";
 
+const pagesDir = "src/pages/";
+const srcTagColors = [
+  "#dc2626",
+  "#d97706",
+  "#65a30d",
+  "#059669",
+  "#0891b2",
+  "#2563eb",
+  "#7c3aed",
+  "#c026d3",
+];
+
 (async function genTags() {
   console.info("Generating tags…");
 
-  const pagesDir = "src/pages";
-  const wholeDir = await fs.readdir(pagesDir, { recursive: true });
-
-  const files = wholeDir
-    .filter((file) => !file.startsWith("_") && file.endsWith(".mdx"))
-    .map((file) => "/" + file);
-
   const tagsObj = { routes: {}, allTags: [], colors: {} };
-  const tagsArr = [];
+  const files = await getFiles();
+  const fillTagsPromises = files.map((filepath) => fillTags(tagsObj, filepath));
 
-  // Tags per sidebar route
-  const fillTagsPromises = files.map(async (filename) => {
-    const content = await fs.readFile(pagesDir + filename);
-    const { data } = matter(content);
-
-    let route = filename.endsWith("index.mdx")
-      ? filename.slice(0, -1 * "index.mdx".length)
-      : filename.slice(0, -1 * ".mdx".length);
-
-    route = route.endsWith("/") ? route.slice(0, -1) || "/" : route;
-
-    tagsObj.routes[route] = data.tags;
-    tagsArr.push(...data.tags);
-  });
-
+  // Fill tagsObj with tags from all files
   await Promise.all(fillTagsPromises);
 
   // Build allTags array with unique tags
-  tagsObj.allTags = [...new Set(tagsArr)].sort();
+  tagsObj.allTags = [...new Set(tagsObj.allTags)].sort();
 
-  // Color per tag
+  fillTagColors(tagsObj);
 
-  const srcColors = [
-    "#dc2626",
-    "#d97706",
-    "#65a30d",
-    "#059669",
-    "#0891b2",
-    "#2563eb",
-    "#7c3aed",
-    "#c026d3",
-  ];
+  await fs.writeFile("src/utils/tags.json", JSON.stringify(tagsObj));
 
-  for (const [index, tag] of tagsObj.allTags.entries()) {
-    tagsObj.colors[tag] = srcColors[index % srcColors.length];
-  }
-
-  await fs.writeFile("./src/utils/tags.json", JSON.stringify(tagsObj));
-  console.info(
-    "Tags successfully generated and written to src/utils/tags.json",
-  );
+  console.info("Tags written to src/utils/tags.json");
 })();
+
+async function getFiles() {
+  const wholeDir = await fs.readdir(pagesDir, { recursive: true });
+
+  const files = wholeDir.filter(
+    (file) =>
+      (file.endsWith(".md") || file.endsWith(".mdx")) && file !== "_app.mdx",
+  );
+
+  return files;
+}
+
+async function fillTags(tagsObj, filepath) {
+  const route = getRoute(filepath);
+  const tags = await getTags(filepath);
+
+  tagsObj.routes[route] = tags;
+  tagsObj.allTags.push(...tags);
+}
+
+function getRoute(filepath) {
+  const extension = "." + filepath.split(".")[1];
+
+  const numCharsToRemove = filepath.endsWith(`index${extension}`)
+    ? `index${extension}`.length
+    : extension.length;
+
+  let route = filepath.slice(0, -1 * numCharsToRemove);
+  route = route.endsWith("/") ? route.slice(0, -1) || "/" : route;
+  route = "/" + route;
+
+  return route;
+}
+
+async function getTags(filepath) {
+  const content = await fs.readFile(pagesDir + filepath);
+  const { data } = matter(content);
+
+  let tags = data.tags || [];
+  tags = Array.isArray(tags) ? tags : [tags];
+  tags = tags.map((tag) => String(tag));
+
+  return tags;
+}
+
+function fillTagColors(tagsObj) {
+  for (const [index, tag] of tagsObj.allTags.entries()) {
+    tagsObj.colors[tag] = srcTagColors[index % srcTagColors.length];
+  }
+}

--- a/src/pages/core.mdx
+++ b/src/pages/core.mdx
@@ -3,9 +3,6 @@ tags: ["core"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Introduction
 

--- a/src/pages/core/entrypoints.mdx
+++ b/src/pages/core/entrypoints.mdx
@@ -3,9 +3,6 @@ tags: ["core"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Entrypoints
 

--- a/src/pages/core/entrypoints/execute.mdx
+++ b/src/pages/core/entrypoints/execute.mdx
@@ -3,8 +3,5 @@ tags: ["core", "entrypoints"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Execute

--- a/src/pages/core/entrypoints/instantiate.mdx
+++ b/src/pages/core/entrypoints/instantiate.mdx
@@ -3,8 +3,5 @@ tags: ["core", "entrypoints"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Instantiate

--- a/src/pages/core/entrypoints/migrate.mdx
+++ b/src/pages/core/entrypoints/migrate.mdx
@@ -3,8 +3,5 @@ tags: ["core", "entrypoints"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Migrate

--- a/src/pages/core/entrypoints/query.mdx
+++ b/src/pages/core/entrypoints/query.mdx
@@ -3,8 +3,5 @@ tags: ["core", "entrypoints"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Query

--- a/src/pages/core/entrypoints/sudo.mdx
+++ b/src/pages/core/entrypoints/sudo.mdx
@@ -3,8 +3,5 @@ tags: ["core", "entrypoints"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Sudo

--- a/src/pages/core/installation.mdx
+++ b/src/pages/core/installation.mdx
@@ -3,9 +3,6 @@ tags: ["core"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Installation
 

--- a/src/pages/core/standard-library.mdx
+++ b/src/pages/core/standard-library.mdx
@@ -3,8 +3,5 @@ tags: ["core"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Standard Library

--- a/src/pages/core/standard-library/cryptography.mdx
+++ b/src/pages/core/standard-library/cryptography.mdx
@@ -3,8 +3,5 @@ tags: ["core"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Cryptography

--- a/src/pages/core/standard-library/math.mdx
+++ b/src/pages/core/standard-library/math.mdx
@@ -3,8 +3,5 @@ tags: ["core"]
 ---
 
 import { Callout } from "nextra/components";
-import Tags from "@/components/Tags";
-
-<Tags />
 
 # Math

--- a/src/pages/cw-multi-test.md
+++ b/src/pages/cw-multi-test.md
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Introduction
 
 Testing tools for multi-contract interactions.

--- a/src/pages/cw-multi-test/examples/advanced.md
+++ b/src/pages/cw-multi-test/examples/advanced.md
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Advanced contract interactions
 
 ---

--- a/src/pages/cw-multi-test/getting-started.md
+++ b/src/pages/cw-multi-test/getting-started.md
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Getting started
 
 ---

--- a/src/pages/cw-multi-test/installation.md
+++ b/src/pages/cw-multi-test/installation.md
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Installation
 
 ---

--- a/src/pages/cw-multi-test/smart-contract-lifetime/create-smart-contract.mdx
+++ b/src/pages/cw-multi-test/smart-contract-lifetime/create-smart-contract.mdx
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 import { Tabs } from "nextra/components";
 
 # Create smart contract

--- a/src/pages/cw-multi-test/smart-contract-lifetime/instantiate-contract.mdx
+++ b/src/pages/cw-multi-test/smart-contract-lifetime/instantiate-contract.mdx
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Instantiate contract
 
 ```rust

--- a/src/pages/cw-multi-test/smart-contract-lifetime/prepare-contract-wrapper.mdx
+++ b/src/pages/cw-multi-test/smart-contract-lifetime/prepare-contract-wrapper.mdx
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Prepare contract wrapper
 
 ```rust

--- a/src/pages/cw-multi-test/smart-contract-lifetime/store-contract-code.mdx
+++ b/src/pages/cw-multi-test/smart-contract-lifetime/store-contract-code.mdx
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Store contract code
 
 ```rust

--- a/src/pages/how-to-doc.md
+++ b/src/pages/how-to-doc.md
@@ -2,10 +2,6 @@
 tags: ["intro", "tutorial"]
 ---
 
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # How to doc
 
 The next articles will teach you the basics for writing documentation using
@@ -17,9 +13,6 @@ The next articles will teach you the basics for writing documentation using
   attracting attention.
 - [Tabs](/how-to-doc/tabs): a Tabs component for switching between related
   content.
-
-Please use the `.mdx` extension for the documentation files, so that tags can be
-properly generated and you can use React components inside.
 
 You can also check out Nextra's [official docs](https://nextra.site/docs) for
 more information.

--- a/src/pages/how-to-doc/callout.mdx
+++ b/src/pages/how-to-doc/callout.mdx
@@ -2,10 +2,6 @@
 tags: ["tutorial", "component"]
 ---
 
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Callout
 
 A built-in component provided by `nextra/components`.

--- a/src/pages/how-to-doc/mdx.mdx
+++ b/src/pages/how-to-doc/mdx.mdx
@@ -2,10 +2,6 @@
 tags: ["tutorial"]
 ---
 
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # MDX
 
 With Nextra, all your `.md` and `.mdx` files under the pages directory will be

--- a/src/pages/how-to-doc/tabs.mdx
+++ b/src/pages/how-to-doc/tabs.mdx
@@ -2,10 +2,6 @@
 tags: ["tutorial", "component"]
 ---
 
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Tabs
 
 A built-in component provided by `nextra-theme-docs`.

--- a/src/pages/how-to-doc/tags.mdx
+++ b/src/pages/how-to-doc/tags.mdx
@@ -5,8 +5,7 @@ tags: ["tutorial", "component"]
 # Tags
 
 A [front matter](https://github.com/jxson/front-matter) attribute allows us to
-define tags per file and a custom React component shows them as pills on the
-website.
+define tags per file.
 
 ## Example
 
@@ -16,33 +15,42 @@ import Tags from "@/components/Tags";
 
 ## Usage
 
-```mdx filename="tags.mdx"
----
-tags: ["tutorial", "component"]
----
+You can use any valid front matter format for the tags attribute, but please
+follow these conventions for consistency:
 
-import Tags from "@/components/Tags";
+import { Tabs } from "nextra/components";
 
-<Tags />
+<Tabs items={['Multiple tags', 'Single tag', 'No tags']}>
+  <Tabs.Tab>
+    ```md filename="multiple-tags.md"
+    ---
+    tags: ["tag-1", "tag-2"]
+    ---
 
-# My new article
+    # My new article
 
-This is an example article with tags.
-```
+    This is an example article with tags.
+    ```
 
-Please use array syntax for the front matter tags even if it's only a single
-tag:
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```md filename="single-tag.md"
+    ---
+    tags: "tag-1"
+    ---
 
-```mdx filename="single-tag.mdx"
----
-tags: ["my-tag"]
----
+    # My new article
 
-import Tags from "@/components/Tags";
+    This is an example article with a tag.
+    ```
 
-<Tags />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```md filename="no-tags.md"
+    # My new article
 
-# My newest article
+    This is an example article with no tags.
+    ```
 
-This is an example article with a single tag.
-```
+  </Tabs.Tab>
+</Tabs>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -2,10 +2,6 @@
 tags: ["intro"]
 ---
 
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Welcome
 
 CosmWasm is a smart contract platform focusing on security, performance, and

--- a/src/pages/sylvia.md
+++ b/src/pages/sylvia.md
@@ -1,11 +1,3 @@
----
-tags: []
----
-
-import Tags from "@/components/Tags";
-
-<Tags />
-
 # Introduction to Sylvia
 
 Sylvia is a framework for building CosmWasm smart contracts with a high level of

--- a/src/theme.config.js
+++ b/src/theme.config.js
@@ -1,4 +1,5 @@
 import TagDots from "@/components/TagDots";
+import Tags from "@/components/Tags";
 import { iceland } from "@/utils/fonts";
 import { useConfig } from "nextra-theme-docs";
 import { useEffect, useState } from "react";
@@ -67,6 +68,12 @@ export default {
       </div>
     ),
   },
+  main: ({ children }) => (
+    <>
+      <Tags />
+      {children}
+    </>
+  ),
   sidebar: {
     autoCollapse: true,
     defaultMenuCollapseLevel: 1,


### PR DESCRIPTION
- Authors no longer need to import and use the `<Tags />` component.
- The `.md` extension can be used if a file does not have any React component like `<Callout />`.
- Front matter tags can be used without array notation and completely omitted if that file has no tags.