### PR TITLE
Docs Test Changes

### DIFF
--- a/docs-test-gen/Cargo.toml
+++ b/docs-test-gen/Cargo.toml
@@ -13,4 +13,4 @@ strum = { version = "0.26.2", features = ["derive"] }
 
 [dev-dependencies]
 cosmwasm-schema = "*"
-cosmwasm-std = "*"
+cosmwasm-std = { version = "*", features = ["stargate", "staking", "cosmwasm_2_0"] }

--- a/docs-test-gen/src/main.rs
+++ b/docs-test-gen/src/main.rs
@@ -7,6 +7,7 @@ use strum::{EnumIter, IntoEnumIterator};
 
 static TEMPLATES: phf::Map<&'static str, &'static str> = phf_map! {
     "core" => include_str!("../templates/core.tpl"),
+    "execute" => include_str!("../templates/execute.tpl"),
 };
 
 fn is_goey(fence: &str) -> bool {

--- a/docs-test-gen/templates/execute.tpl
+++ b/docs-test-gen/templates/execute.tpl
@@ -1,0 +1,22 @@
+use cosmwasm_std::*;
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+struct ExecuteMsg {}
+
+#[entry_point]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    {{code}}
+}
+
+#[test]
+fn doctest() {
+    use cosmwasm_std::testing::*;
+
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
+    let msg = ExecuteMsg {};
+
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+}

--- a/docs-test-gen/templates/execute.tpl
+++ b/docs-test-gen/templates/execute.tpl
@@ -6,7 +6,17 @@ struct ExecuteMsg {}
 
 #[entry_point]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
-    {{code}}
+    // this weird construction allows us to return a StdResult<Response> or () in the code
+    // it tricks the compiler into infering the correct generics
+    trait ValidReturn {}
+    impl ValidReturn for StdResult<Response<Empty>> {}
+    impl ValidReturn for () {}
+    fn assert_valid_return(_: &impl ValidReturn) {}
+
+    let ret = { {{code}} };
+    assert_valid_return(&ret);
+
+    Ok(Response::default())
 }
 
 #[test]

--- a/scripts/test-rust.sh
+++ b/scripts/test-rust.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+(
+    cd docs-test-gen && \
+    rm -rf ./tests && \
+    cargo run &&
+    cargo test
+)


### PR DESCRIPTION
* Adds a new template (I'll use that in the IBC PR, but it's probably useful for others too)
* Adds a small script to regenerate and run the tests
* Enable all features for cosmwasm-std (IBC for example needs stargate, but we might need the others for core too)