### PR TITLE
Set up `cw-storage-plus` outline

### DIFF
--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -2,6 +2,7 @@
   "index": "Welcome",
   "core": "CosmWasm Core",
   "sylvia": "Sylvia",
+  "cw-storage-plus": "cw-storage-plus",
   "cw-multi-test": "MultiTest",
   "how-to-doc": "How to doc",
   "tags": {

--- a/src/pages/cw-storage-plus.md
+++ b/src/pages/cw-storage-plus.md
@@ -1,0 +1,4 @@
+# Introduction
+
+TODO: Describe what low-level interface `cw-storage-plus` builds on, and how it
+provides typed abstractions on top of it

--- a/src/pages/cw-storage-plus/_meta.json
+++ b/src/pages/cw-storage-plus/_meta.json
@@ -1,0 +1,8 @@
+{
+  "basics": "Basics",
+  "containers": "Containers",
+  "key-collisions": "Key collisions",
+  "iteration": "Iteration",
+  "snapshots": "Snapshots",
+  "multi-indexes": "Multi index collections"
+}

--- a/src/pages/cw-storage-plus/basics.md
+++ b/src/pages/cw-storage-plus/basics.md
@@ -1,0 +1,4 @@
+# Basics
+
+TODO: Describe the way storage containers generally work, how prefixes provide a
+"slice" of the whole namespace, etc

--- a/src/pages/cw-storage-plus/containers/_meta.json
+++ b/src/pages/cw-storage-plus/containers/_meta.json
@@ -1,0 +1,5 @@
+{
+  "item": "Item",
+  "map": "Map",
+  "deque": "Deque"
+}

--- a/src/pages/cw-storage-plus/containers/deque.mdx
+++ b/src/pages/cw-storage-plus/containers/deque.mdx
@@ -1,0 +1,7 @@
+# `Deque`
+
+## Overview
+
+## Examples
+
+### ?

--- a/src/pages/cw-storage-plus/containers/item.mdx
+++ b/src/pages/cw-storage-plus/containers/item.mdx
@@ -1,0 +1,9 @@
+# `Item`
+
+## Overview
+
+## Examples
+
+### Saving an admin address
+
+### Saving a config structure

--- a/src/pages/cw-storage-plus/containers/map.mdx
+++ b/src/pages/cw-storage-plus/containers/map.mdx
@@ -1,0 +1,7 @@
+# `Map`
+
+## Overview
+
+## Examples
+
+### Keeping users' balances

--- a/src/pages/cw-storage-plus/iteration.md
+++ b/src/pages/cw-storage-plus/iteration.md
@@ -1,0 +1,9 @@
+# Iteration
+
+TODO: how to generally take advantage of iteration
+
+TODO: bounds, inclusive-exclusive
+
+TODO: `Map` iteration - surprising behavior with order and bounds?
+
+TODO: how to use `Prefix` and such

--- a/src/pages/cw-storage-plus/key-collisions.mdx
+++ b/src/pages/cw-storage-plus/key-collisions.mdx
@@ -1,0 +1,12 @@
+import { Callout } from "nextra/components";
+
+# Key collisions
+
+TODO: Explain how key collisions shouldn't generally happen as long as unique
+prefixes are chosen
+
+<Callout type="warning">
+  Warning here about a potential nefarious key collision below
+</Callout>
+
+https://confio.slack.com/archives/C06A73TKXST/p1709815517501709

--- a/src/pages/cw-storage-plus/multi-indexes.md
+++ b/src/pages/cw-storage-plus/multi-indexes.md
@@ -1,0 +1,3 @@
+# Multi index collections
+
+TODO: bonus section, maybe flesh out, maybe remove

--- a/src/pages/cw-storage-plus/snapshots.md
+++ b/src/pages/cw-storage-plus/snapshots.md
@@ -1,0 +1,3 @@
+# Snapshots
+
+TODO: bonus section, maybe flesh out, maybe remove


### PR DESCRIPTION
This ports the [outline](https://confio.slab.com/posts/cw-storage-plus-docs-outline-40du12x6) for `cw-storage-plus` here.