### PR TITLE
Add documentation about measuring time

### DIFF
--- a/src/pages/core/_meta.json
+++ b/src/pages/core/_meta.json
@@ -3,5 +3,6 @@
   "entrypoints": "Entrypoints",
   "architecture": "Architecture",
   "standard-library": "Standard Library",
+  "advanced": "Advanced",
   "specification": "Specification"
 }

--- a/src/pages/core/advanced.mdx
+++ b/src/pages/core/advanced.mdx
@@ -1,0 +1,17 @@
+---
+tags: ["core", "advanced"]
+---
+
+import { Callout } from "nextra/components";
+
+# Advanced topics
+
+In this part of the documentation, we go over some more "advanced" things you
+can do with the functionality CosmWasm core offers.
+
+<Callout>
+  While the name of this section is "advanced", this doesn't mean that we want
+  to imply that you only need these functions in advanced contexts. The wording
+  "advanced" moreso refers to the fact that you should be familiar with
+  endpoints, the structs that are passed to the endpoints, etc.
+</Callout>

--- a/src/pages/core/advanced/_meta.json
+++ b/src/pages/core/advanced/_meta.json
@@ -1,0 +1,3 @@
+{
+  "measuring-time": "Measuring time"
+}

--- a/src/pages/core/advanced/measuring-time.mdx
+++ b/src/pages/core/advanced/measuring-time.mdx
@@ -11,7 +11,7 @@ hard. It is hard to coordinate, hard to keep in sync, and this gets worse in
 distributed settings such as blockchains.
 
 In CosmWasm, we solve this by passing you some information about the blockchain
-you are running on whenever en entrypoint is invoked.
+you are running on whenever an entrypoint is invoked.
 
 In each of the entrypoints, you get a parameter of the type `Env` and this
 struct contains the field `block`. The struct contained in this field has a

--- a/src/pages/core/advanced/measuring-time.mdx
+++ b/src/pages/core/advanced/measuring-time.mdx
@@ -23,8 +23,7 @@ running on.
 
 The timestamp contained in this struct can be safely used in your program as the
 source of the current time. Well, kinda. It won't be 100% matching the current
-time, as it will only definitely match the time the latest block on the
-blockchain as of the invocation of your contract.
+time, as it is the timestamp of the block we are currently operating on.
 
 But you can rely on this timestamp to have the following properties:
 

--- a/src/pages/core/advanced/measuring-time.mdx
+++ b/src/pages/core/advanced/measuring-time.mdx
@@ -1,0 +1,32 @@
+---
+tags: ["core", "advanced"]
+---
+
+import { Callout } from "nextra/components";
+
+# Measuring time
+
+Accessing the current time is useful in a lot of different contexts but time is
+hard. It is hard to coordinate, hard to keep in sync, and this gets worse in
+distributed settings such as blockchains.
+
+In CosmWasm, we solve this by passing you some information about the blockchain
+you are running on whenever en entrypoint is invoked.
+
+In each of the entrypoints, you get a parameter of the type `Env` and this
+struct contains the field `block`. The struct contained in this field has a
+bunch of different information about the current state of the blockchain you are
+running on.
+
+> The documentation about the `BlockInfo` struct can be
+> [found here](https://docs.rs/cosmwasm-std/2.0.4/cosmwasm_std/struct.BlockInfo.html)
+
+The timestamp contained in this struct can be safely used in your program as the
+source of the current time. Well, kinda. It won't be 100% matching the current
+time, as it will only definitely match the time the latest block on the
+blockchain as of the invocation of your contract.
+
+But you can rely on this timestamp to have the following properties:
+
+- Consistent across the chain (every validator on the chain has the same info)
+- Monotonic (it will ever only increase or stay the same; never decrease)

--- a/src/pages/core/advanced/measuring-time.mdx
+++ b/src/pages/core/advanced/measuring-time.mdx
@@ -19,7 +19,7 @@ bunch of different information about the current state of the blockchain you are
 running on.
 
 > The documentation about the `BlockInfo` struct can be
-> [found here](https://docs.rs/cosmwasm-std/2.0.4/cosmwasm_std/struct.BlockInfo.html)
+> [found here](https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.BlockInfo.html)
 
 The timestamp contained in this struct can be safely used in your program as the
 source of the current time. Well, kinda. It won't be 100% matching the current


### PR DESCRIPTION
This adds some information on how to access a monotonic clock that also contains a consistent timestamp.  
This is a shorter version of [this chapter](https://book.cosmwasm.com/cross-contract/working-with-time.html) in the book.