### PR TITLE
Add Storey examples to IBC packet docs

### DIFF
--- a/docs-test-gen/src/main.rs
+++ b/docs-test-gen/src/main.rs
@@ -10,6 +10,7 @@ static TEMPLATES: phf::Map<&'static str, &'static str> = phf_map! {
     "execute" => include_str!("../templates/execute.tpl"),
     "instantiate-spec" => include_str!("../templates/instantiate-spec.tpl"),
     "ibc-channel" => include_str!("../templates/ibc-channel.tpl"),
+    "ibc-packet" => include_str!("../templates/ibc-packet.tpl"),
     "storage" => include_str!("../templates/storage.tpl"),
 };
 

--- a/docs-test-gen/templates/execute.tpl
+++ b/docs-test-gen/templates/execute.tpl
@@ -7,7 +7,7 @@ struct ExecuteMsg {}
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     // this weird construction allows us to return a StdResult<Response> or () in the code
-    // it tricks the compiler into infering the correct generics
+    // it tricks the compiler into inferring the correct generics
     trait ValidReturn {}
     impl ValidReturn for StdResult<Response<Empty>> {}
     impl ValidReturn for () {}

--- a/docs-test-gen/templates/ibc-packet.tpl
+++ b/docs-test-gen/templates/ibc-packet.tpl
@@ -1,0 +1,44 @@
+use cosmwasm_std::*;
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+struct ChannelInfo {
+    channel_id: String,
+    /// whether the channel is completely set up
+    finalized: bool,
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: Empty) -> StdResult<Response> {
+    {{code}}
+}
+
+#[test]
+fn doctest() {
+    use cosmwasm_std::testing::*;
+
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
+    let msg = Empty {};
+
+    // prepare channel info
+    let channel_info = ChannelInfo {
+        channel_id: "channel-0".to_string(),
+        finalized: false,
+    };
+    // save channel to storage for both StoragePlus and Storey
+    {
+        use cw_storage_plus::Item;
+        const CHANNEL: Item<ChannelInfo> = Item::new("channel");
+        CHANNEL.save(&mut deps.storage, &channel_info).unwrap();
+    }
+    {
+        use cw_storey::{containers::Item, CwStorage};
+        const CHANNEL: Item<ChannelInfo> = Item::new(0);
+        CHANNEL.access(&mut CwStorage(&mut deps.storage)).set(&channel_info).unwrap();
+    }
+
+
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+}

--- a/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
+++ b/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
@@ -2,7 +2,7 @@
 tags: ["ibc", "ics4"]
 ---
 
-import { Callout } from "nextra/components";
+import { Callout, Tabs } from "nextra/components";
 
 # Packet lifecycle
 
@@ -34,11 +34,18 @@ A visual representation of these flows can be found in the
 In order to send a packet, you need to send the `IbcMsg::SendPacket` message. It
 looks like this:
 
-```rust template="execute"
-// TODO: load channel id from state?
+<Tabs items={['StoragePlus', 'Storey']}>
+  <Tabs.Tab>
+
+```rust template="ibc-packet"
+use cw_storage_plus::Item;
+
+const CHANNEL: Item<ChannelInfo> = Item::new("channel");
+
+let channel_id = CHANNEL.load(deps.storage)?.channel_id;
 // construct the transfer message
 let msg = IbcMsg::SendPacket {
-    channel_id: "channel-0".to_string(),
+    channel_id,
     data: br#"{"hello":{"text":"Hello, chain B!"}}"#.into(),
     timeout: IbcTimeout::with_block(IbcTimeoutBlock {
         revision: 4,
@@ -50,6 +57,35 @@ let msg = IbcMsg::SendPacket {
 Ok(Response::new().add_message(msg))
 ```
 
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+```rust template="ibc-packet"
+use cw_storey::{containers::Item, CwStorage};
+
+const CHANNEL: Item<ChannelInfo> = Item::new(0);
+
+let channel_id = CHANNEL
+    .access(&mut CwStorage(deps.storage))
+    .get()?
+    .ok_or_else(|| StdError::generic_err("channel handshake hasn't started yet"))?
+    .channel_id;
+// construct the transfer message
+let msg = IbcMsg::SendPacket {
+    channel_id,
+    data: br#"{"hello":{"text":"Hello, chain B!"}}"#.into(),
+    timeout: IbcTimeout::with_block(IbcTimeoutBlock {
+        revision: 4,
+        height: 1000,
+    }),
+};
+
+// attach the message and return the response
+Ok(Response::new().add_message(msg))
+```
+
+  </Tabs.Tab>
+</Tabs>
 The `channel_id` is the identifier of the channel you want to use for the
 packet. This must be a channel that was previously established, as described in
 the [previous section], so you probably want to load this from contract state.


### PR DESCRIPTION
Async ack example using storey not added yet, as storey currently only supports String keys and that would complicate the example a bit. See https://github.com/CosmWasm/storey/issues/48