### PR TITLE
Add formatter script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+[*.rs]
+indent_size = 4
+max_line_length = 100
+
+[*.{md,mdx}]
+max_line_length = 100

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+# Running with -c makes the script only validate instead of editing in place.
+op="write"
+while getopts c option; do
+  case "${option}" in
+  c) op="check" ;;
+  *) ;;
+  esac
+done
+
+npx prettier@3.3.3 --$op --no-config "./src/**/*.md" "./src/**/*.mdx"

--- a/src/pages/core/advanced/measuring-time.mdx
+++ b/src/pages/core/advanced/measuring-time.mdx
@@ -29,5 +29,4 @@ But you can rely on this timestamp to have the following properties:
 - Consistent across the chain (every validator on the chain has the same info)
 - Monotonic (it will ever only increase or stay the same; never decrease)
 
-[found here]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.BlockInfo.html
+[found here]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.BlockInfo.html

--- a/src/pages/core/architecture/actor-model.mdx
+++ b/src/pages/core/architecture/actor-model.mdx
@@ -64,8 +64,6 @@ mid-execution and make your contract exhibit buggy behaviour.
 CosmWasm effectively forces you to follow the [CEI pattern (Checks, Effects,
 Interactions)] while other similar systems only have this as a "best practice".
 
-[reentrancy issues]:
-  https://ethereum.org/en/developers/docs/smart-contracts/security/#reentrancy
+[reentrancy issues]: https://ethereum.org/en/developers/docs/smart-contracts/security/#reentrancy
 [enum dispatch]: ../conventions/enum-dispatch
-[CEI pattern (Checks, Effects, Interactions)]:
-  https://fravoll.github.io/solidity-patterns/checks_effects_interactions.html
+[CEI pattern (Checks, Effects, Interactions)]: https://fravoll.github.io/solidity-patterns/checks_effects_interactions.html

--- a/src/pages/core/architecture/gas.mdx
+++ b/src/pages/core/architecture/gas.mdx
@@ -98,7 +98,6 @@ jq).
 
 [#1599]: https://github.com/CosmWasm/cosmwasm/pull/1599
 [JSON numbers]: https://www.json.org/
-[defaultgasmultiplier]:
-  https://github.com/CosmWasm/wasmd/blob/v0.19.0/x/wasm/keeper/gas_register.go#L18
+[defaultgasmultiplier]: https://github.com/CosmWasm/wasmd/blob/v0.19.0/x/wasm/keeper/gas_register.go#L18
 [neargas]: https://docs.near.org/docs/concepts/gas
 [#1120]: https://github.com/CosmWasm/cosmwasm/pull/1120

--- a/src/pages/core/architecture/pinning.mdx
+++ b/src/pages/core/architecture/pinning.mdx
@@ -84,19 +84,14 @@ Pinning was developed in 2021 (CosmWasm 0.14) for the Proof of Engagement
 consensus system of Tgrade which required certain contracts to be executed in
 every block.
 
-[metrics]:
-  https://github.com/CosmWasm/wasmvm/blob/v2.0.0-rc.2/types/types.go#L174-L185
-[`cache::pin`]:
-  https://docs.rs/cosmwasm-vm/latest/cosmwasm_vm/struct.Cache.html#method.pin
-[`cache::unpin`]:
-  https://docs.rs/cosmwasm-vm/latest/cosmwasm_vm/struct.Cache.html#method.unpin
-[08-wasm]:
-  https://github.com/cosmos/ibc-go/tree/main/modules/light-clients/08-wasm
-[initializepinnedcodes]:
-  https://github.com/CosmWasm/wasmd/blob/v0.50.0/x/wasm/keeper/keeper.go#L1011-L1028
+[metrics]: https://github.com/CosmWasm/wasmvm/blob/v2.0.0-rc.2/types/types.go#L174-L185
+[`cache::pin`]: https://docs.rs/cosmwasm-vm/latest/cosmwasm_vm/struct.Cache.html#method.pin
+[`cache::unpin`]: https://docs.rs/cosmwasm-vm/latest/cosmwasm_vm/struct.Cache.html#method.unpin
+[08-wasm]: https://github.com/cosmos/ibc-go/tree/main/modules/light-clients/08-wasm
+[initializepinnedcodes]: https://github.com/CosmWasm/wasmd/blob/v0.50.0/x/wasm/keeper/keeper.go#L1011-L1028
 [Prometheus]: https://prometheus.io/
-[neutron-case-study]:
-  https://medium.com/confio/neutron-case-study-optimizing-gas-usage-with-contract-pinning-5970a109c706
+[neutron-case-study]: https://medium.com/confio/neutron-case-study-optimizing-gas-usage-with-contract-pinning-5970a109c706
 
 [^1]: https://github.com/CosmWasm/wasmd/pull/1799
+
 [^2]: https://github.com/CosmWasm/cosmwasm/issues/2034

--- a/src/pages/core/conventions/library-feature.mdx
+++ b/src/pages/core/conventions/library-feature.mdx
@@ -54,5 +54,4 @@ Using this library feature will enable developers to use your contract as a
 dependency and reuse your code.
 
 [`cw-plus` contracts]: https://github.com/CosmWasm/cw-plus
-[`cw4-stake` contract]:
-  https://github.com/CosmWasm/cw-plus/blob/48bec694521655d5b3e688c51e4185f740ea4640/contracts/cw4-stake/Cargo.toml#L22-L24
+[`cw4-stake` contract]: https://github.com/CosmWasm/cw-plus/blob/48bec694521655d5b3e688c51e4185f740ea4640/contracts/cw4-stake/Cargo.toml#L22-L24

--- a/src/pages/core/entrypoints.mdx
+++ b/src/pages/core/entrypoints.mdx
@@ -37,16 +37,16 @@ VM: "Hey! This is an entrypoint, please use it when needed!"
   When defining an entrypoint, it is important to use the correct types for the
   parameters and return type. Incorrect types will cause errors when trying to
   call the contract.
-  <br /> In the following sections we will take a look at all possible entrypoints,
-  including the correct function signature.
+  <br /> In the following sections we will take a look at all possible
+  entrypoints, including the correct function signature.
 </Callout>
 
 <Callout>
   Even though the sections will show you to use `#[entry_point]`, it is
   recommended to define your endpoints as `#[cfg_attr(not(feature = "library"),
   entry_point)]`.
-  <br /> The reason behind that is that it allows you to reuse your contract as a
-  library.
+  <br /> The reason behind that is that it allows you to reuse your contract as
+  a library.
 </Callout>
 
 ```rust template="core"

--- a/src/pages/core/installation.mdx
+++ b/src/pages/core/installation.mdx
@@ -30,9 +30,9 @@ platform.
     <summary>Additional information about the Optimizing Compiler</summary>
 
     Please note that this image is intended for reproducible production builds.
-    It is _not_ optimized for development or in general environments where you 
-    want to iterate quickly. The builder is optimizing for size, not compilation speed. 
-    If you want to slim down your contract for development, you can do so by 
+    It is _not_ optimized for development or in general environments where you
+    want to iterate quickly. The builder is optimizing for size, not compilation speed.
+    If you want to slim down your contract for development, you can do so by
     tweaking your Cargo profile.
 
     ```toml

--- a/src/pages/core/standard-library/cryptography.mdx
+++ b/src/pages/core/standard-library/cryptography.mdx
@@ -81,5 +81,4 @@ execution is quite fast. In most cases the perceived need to move hashing into a
 host function is premature optimization and not actually needed.
 
 [check this page]: ../architecture/gas
-[source code]:
-  https://github.com/CosmWasm/cosmwasm/blob/main/packages/vm/src/environment.rs#L62-L101
+[source code]: https://github.com/CosmWasm/cosmwasm/blob/main/packages/vm/src/environment.rs#L62-L101

--- a/src/pages/core/standard-library/cryptography/ed25519.mdx
+++ b/src/pages/core/standard-library/cryptography/ed25519.mdx
@@ -37,6 +37,5 @@ pub fn query(
 }
 ```
 
-[have issues with inconsistent validation criteria]:
-  https://hdevalence.ca/blog/2020-10-04-its-25519am
+[have issues with inconsistent validation criteria]: https://hdevalence.ca/blog/2020-10-04-its-25519am
 [ZIP215]: https://zips.z.cash/zip-0215

--- a/src/pages/cw-storage-plus/containers/indexed-map.mdx
+++ b/src/pages/cw-storage-plus/containers/indexed-map.mdx
@@ -112,9 +112,10 @@ Here's what happens step-by-step
   [`UniqueIndex`](https://docs.rs/cw-storage-plus/latest/cw_storage_plus/struct.UniqueIndex.html),
   it's your responsibility to ensure that the index you've built has unique
   keys. If you have two users with the same handle, the index will be
-  overwritten and only contain the last user. Be careful!
-  
-  If you need to store a key that is not unique, you'll want to use a [`MultiIndex`](https://docs.rs/cw-storage-plus/latest/cw_storage_plus/struct.MultiIndex.html) - see [*Lookup by country*](#lookup-by-country).
+  overwritten and only contain the last user. Be careful! If you need to store a
+  key that is not unique, you'll want to use a
+  [`MultiIndex`](https://docs.rs/cw-storage-plus/latest/cw_storage_plus/struct.MultiIndex.html)
+  - see [*Lookup by country*](#lookup-by-country).
 </Callout>
 
 <Callout>

--- a/src/pages/cw-storage-plus/containers/item.mdx
+++ b/src/pages/cw-storage-plus/containers/item.mdx
@@ -120,5 +120,4 @@ counter.save(&mut storage, &total).unwrap();
 ```
 
 [`serde`]: https://serde.rs/
-[API docs]:
-  https://docs.rs/cw-storage-plus/latest/cw_storage_plus/struct.Item.html
+[API docs]: https://docs.rs/cw-storage-plus/latest/cw_storage_plus/struct.Item.html

--- a/src/pages/ibc.mdx
+++ b/src/pages/ibc.mdx
@@ -14,5 +14,4 @@ protocols on top of it, but you can also use existing protocols like the [ICS-20
 token transfer protocol]. In the following sections, we will explain how both of
 these work.
 
-[ICS-20 token transfer protocol]:
-  https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
+[ICS-20 token transfer protocol]: https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md

--- a/src/pages/ibc/diy-protocol/channel-lifecycle.mdx
+++ b/src/pages/ibc/diy-protocol/channel-lifecycle.mdx
@@ -22,10 +22,8 @@ is encoded in the [`IbcOrder`] enum. In an ordered channel, packets must be
 processed by the receiving chain in the order in which they were sent. In an
 unordered channel, packets are processed in the order they arrive.
 
-[`IbcOrder`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcOrder.html
-[ICS 004 specification]:
-  https://github.com/cosmos/ibc/tree/main/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+[`IbcOrder`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcOrder.html
+[ICS 004 specification]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
 [IBC channel docs]: https://ibc.cosmos.network/main/ibc/overview#channels
 
 ## Establishing a channel
@@ -48,8 +46,7 @@ of the steps:
 3. `ibc_channel_connect` on chain A with `IbcChannelConnectMsg::OpenAck`
 4. `ibc_channel_connect` on chain B with `IbcChannelConnectMsg::OpenConfirm`
 
-[hermes]:
-  https://hermes.informal.systems/tutorials/local-chains/add-a-new-relay-path.html#3-channel-identifiers
+[hermes]: https://hermes.informal.systems/tutorials/local-chains/add-a-new-relay-path.html#3-channel-identifiers
 
 ### Channel open
 
@@ -189,8 +186,7 @@ it. The version is used to ensure that both chains are running the protocol that
 the other one expects. You can also return `None` if you just want to accept the
 counterparty version.
 
-[`IbcChannelOpenMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcChannelOpenMsg.html
+[`IbcChannelOpenMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcChannelOpenMsg.html
 
 #### Permissions
 
@@ -418,8 +414,7 @@ const CHANNEL: Item<ChannelInfo> = Item::new(0);
   </Tabs.Tab>
 </Tabs>
 
-[`IbcChannelConnectMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcChannelConnectMsg.html
+[`IbcChannelConnectMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcChannelConnectMsg.html
 
 ## Closing a channel
 
@@ -452,5 +447,4 @@ In this entrypoint, you can handle the closing process as you see fit. This can
 involve cleaning up any storage related to the channel or simply returning an
 error to prevent the channel from closing.
 
-[`IbcChannelCloseMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcChannelCloseMsg.html
+[`IbcChannelCloseMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcChannelCloseMsg.html

--- a/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
+++ b/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
@@ -161,12 +161,10 @@ will revert all state changes and **fail** the transaction. One use case for
 this is implementing a relayer allowlist because the failed receive can then be
 picked up by another relayer.
 
-[`IbcReceiveResponse`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.Response.html
+[`IbcReceiveResponse`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.Response.html
 [`execute`]: ../../core/entrypoints/execute
 [`StdAck`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.StdAck.html
-[ICS-20]:
-  https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
+[ICS-20]: https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
 
 ### Async acknowledgement
 
@@ -263,8 +261,7 @@ When this entrypoint is called, it means that the packet has been successfully
 delivered to chain B and has been processed by the counterparty. This is the
 happy path of the packet lifecycle.
 
-[`IbcPacketAckMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcPacketAckMsg.html
+[`IbcPacketAckMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcPacketAckMsg.html
 
 ## Receiving a packet timeout
 
@@ -298,8 +295,7 @@ Note that the timeout is based on when the packet is _received_ on chain B,
 _not_ on when it is _acknowledged_. This means that a packet that is received,
 but not acknowledged will **not** trigger a timeout.
 
-[`IbcPacketTimeoutMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcPacketTimeoutMsg.html
+[`IbcPacketTimeoutMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcPacketTimeoutMsg.html
 
 ## State rewinding
 

--- a/src/pages/ibc/existing-protocols.mdx
+++ b/src/pages/ibc/existing-protocols.mdx
@@ -17,8 +17,7 @@ An example for the latter is the [Nois protocol]. It provides a proxy contract
 that handles all the IBC logic for you. We will later cover how to implement
 your own IBC protocol.
 
-[ICS20]:
-  https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
+[ICS20]: https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
 [Nois protocol]: https://docs.nois.network/dapp_devs/use_nois_randomness.html
 
 ## Example: `IbcMsg::Transfer`
@@ -65,10 +64,8 @@ The `memo` is an optional field that can be used to attach a message to the
 transfer. It is often used for additional functionality like
 [packet-forward-middleware] or IBC Callbacks.
 
-[packet-forward-middleware]:
-  https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware
-[Cosmos Developer Portal]:
-  https://tutorials.cosmos.network/tutorials/6-ibc-dev/#understand-ibc-denoms
+[packet-forward-middleware]: https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware
+[Cosmos Developer Portal]: https://tutorials.cosmos.network/tutorials/6-ibc-dev/#understand-ibc-denoms
 
 ## ADR-8: IBC Callbacks
 
@@ -81,10 +78,8 @@ triggers callbacks when a packet is received.
 
 IBC Callbacks is a generalized successor of [IBC Hooks][ibc-hooks].
 
-[adr-8]:
-  https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-008-app-caller-cbs.md
-[ibc-hooks]:
-  https://github.com/cosmos/ibc-apps/blob/main/modules/ibc-hooks/README.md
+[adr-8]: https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-008-app-caller-cbs.md
+[ibc-hooks]: https://github.com/cosmos/ibc-apps/blob/main/modules/ibc-hooks/README.md
 
 <Callout>
   To receive callbacks, the chain needs to support IBC Callbacks for the message
@@ -108,8 +103,7 @@ JSON. One is a builder type for the `IbcMsg::Transfer` type which provides a
 type-safe way to generate the complete `IbcMsg::Transfer`, the other is a helper
 type [`IbcCallbackRequest`] that just generates the JSON for the `memo` field:
 
-[`IbcCallbackRequest`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcCallbackRequest.html
+[`IbcCallbackRequest`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcCallbackRequest.html
 
 <Tabs items={['TransferMsgBuilder (recommended)', 'IbcCallbackRequest']}>
     <Tabs.Tab>
@@ -183,14 +177,10 @@ contract:
   - [`IbcTimeoutCallbackMsg`] if the packet timed out
 - `ibc_destination_callback`, receiving an [`IbcDestinationCallbackMsg`]
 
-[`IbcSourceCallbackMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcSourceCallbackMsg.html
-[`IbcAckCallbackMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcAckCallbackMsg.html
-[`IbcTimeoutCallbackMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcTimeoutCallbackMsg.html
-[`IbcDestinationCallbackMsg`]:
-  https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcDestinationCallbackMsg.html
+[`IbcSourceCallbackMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/enum.IbcSourceCallbackMsg.html
+[`IbcAckCallbackMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcAckCallbackMsg.html
+[`IbcTimeoutCallbackMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcTimeoutCallbackMsg.html
+[`IbcDestinationCallbackMsg`]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.IbcDestinationCallbackMsg.html
 
 #### Source Callback
 
@@ -352,8 +342,7 @@ sure that the transfer was successful, that the receiver of the funds is your
 contract and the denomination is what you want to receive. This requires some
 knowledge about the [packet format].
 
-[packet format]:
-  https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md#data-structures
+[packet format]: https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md#data-structures
 
 #### Error handling
 

--- a/src/pages/storey.mdx
+++ b/src/pages/storey.mdx
@@ -16,11 +16,11 @@ While StoragePlus has been around for years and is the established way of
 storing your data on-chain, Storey is the new kid on the block.
 
 <Callout type="warning">
-Storey is currently **prototype software**, meaning the API might change
-rapidly, **storage layout might break between versions**, and you might stumble
-into bugs and missing features. It's probably a good idea not to use it for
-serious production software just yet. If you do, please keep in mind the
-increased maintenance burden and be careful!
+  Storey is currently **prototype software**, meaning the API might change
+  rapidly, **storage layout might break between versions**, and you might
+  stumble into bugs and missing features. It's probably a good idea not to use
+  it for serious production software just yet. If you do, please keep in mind
+  the increased maintenance burden and be careful!
 </Callout>
 
 On the other hand, it is a solution we want to move toward - we appreciate

--- a/src/pages/storey/containers.mdx
+++ b/src/pages/storey/containers.mdx
@@ -37,9 +37,9 @@ and any key that starts with that same byte (e.g. `A28F`). In this way, a whole
 namespace is reserved for the container.
 
 <Callout>
-An item will simply store its value under the given byte, while a map will
-store its values under keys that are prefixed with the given byte. How exactly
-the namespace is managed is up to the container implementation.
+  An item will simply store its value under the given byte, while a map will
+  store its values under keys that are prefixed with the given byte. How exactly
+  the namespace is managed is up to the container implementation.
 </Callout>
 
 To avoid key collisions, you must provide a different byte to each container.


### PR DESCRIPTION
This allows us to do `./scripts/format.sh` and format all markdown files. Once this works, we can automate formatting in the CI as shopwn here: https://github.com/CosmWasm/cosmwasm/pull/2189