### PR TITLE
Template for IBC example

### DIFF
--- a/docs-test-gen/Cargo.lock
+++ b/docs-test-gen/Cargo.lock
@@ -387,15 +387,15 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d075f6bb1483a6ce83b5cbc73a3a1207e0316ac1e34ed1f2a4d9fc3a0f07bf6"
+checksum = "367fc87c43759098a476ef90f915aadc66c300480ad9c155b512081fbf327bc1"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ced5a6dd2801a383d3e14e5ae5caa7fdfeff1bd9f22b30e810e0aded8a5869"
+checksum = "9b7c41f3e371ea457d3b98bb592c38858b46efcf614e0e988ec2ebbdb973954f"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd1873f84d9b17edf8a90ffe10a89a649b82feacc00e36788b81d2c3cbf03c"
+checksum = "c10510e8eb66cf7e109741b1e2c76ad18f30b5a1daa064f5f7115c1f733aaea0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27984b137eb2ac561f97f6bdb02004a98eb6f2ba263062c140b8e231ee1826b7"
+checksum = "f79879b6b7ef6a331b05030ce91ce46a7c4b0baf1ed6b382cce2e9a168109380"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ef0d201f611bdb6c9124207032423eb956f1fc8ab3e3ee7253a9c08a5f5809"
+checksum = "82b53e33c0e97170c7ac9cb440f4bc599a07f9cbb9b7e87916cca37b1239d57b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2522fb5c9a0409712bb1d036128bccf3564e6b2ac82f942ae4cf3c8df3e26fa8"
+checksum = "92011c39570876f340d5f9defa68bf92797b1c44421f1b9ea9b04a31d6defd33"
 dependencies = [
  "base64 0.22.1",
  "bech32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "gray-matter": "^4.0.3",
         "husky": "^9.0.11",
         "postcss": "^8.4.38",
-        "prettier": "3.3.2",
+        "prettier": "3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.5",
         "tailwindcss": "^3.4.4"
       }
@@ -5894,9 +5894,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gray-matter": "^4.0.3",
     "husky": "^9.0.11",
     "postcss": "^8.4.38",
-    "prettier": "3.3.2",
+    "prettier": "3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.5",
     "tailwindcss": "^3.4.4"
   }

--- a/src/pages/ibc/existing-protocols.mdx
+++ b/src/pages/ibc/existing-protocols.mdx
@@ -13,8 +13,8 @@ One example for the former is the `IbcMsg::Transfer` message, which causes an [I
 message is included in the CosmWasm standard library. It causes the chain's IBC transfer module to
 send tokens to another chain.
 
-An example for the latter is the [Nois protocol]. It provides a proxy contract that handles all the
-IBC logic for you. We will later cover how to implement your own IBC protocol.
+An example for the latter is the [Nois protocol]. It provides a proxy contract that handles all the IBC
+logic for you. We will later cover how to implement your own IBC protocol.
 
 [ICS20]: https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
 [Nois protocol]: https://docs.nois.network/dapp_devs/use_nois_randomness.html

--- a/src/pages/ibc/existing-protocols.mdx
+++ b/src/pages/ibc/existing-protocols.mdx
@@ -13,8 +13,8 @@ One example for the former is the `IbcMsg::Transfer` message, which causes an [I
 message is included in the CosmWasm standard library. It causes the chain's IBC transfer module to
 send tokens to another chain.
 
-An example for the latter is the [Nois protocol]. It provides a proxy contract that handles all the IBC
-logic for you. We will later cover how to implement your own IBC protocol.
+An example for the latter is the [Nois protocol]. It provides a proxy contract that handles all the
+IBC logic for you. We will later cover how to implement your own IBC protocol.
 
 [ICS20]: https://github.com/cosmos/ibc/blob/main/spec/app/ics-020-fungible-token-transfer/README.md
 [Nois protocol]: https://docs.nois.network/dapp_devs/use_nois_randomness.html
@@ -188,9 +188,7 @@ need for validation.
 
 This is how you can implement the `ibc_source_callback` entrypoint:
 
-{/* TODO: Add template="core" when cosmwasm 2.1.1 is released (fields are currently private) */}
-
-```rust
+```rust template="core"
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_source_callback(
     deps: DepsMut,


### PR DESCRIPTION
closes #47

This adds the `template="core"` to the last missing IBC example. This was not possible before 2.1.1 because the cosmwasm-std types were broken.

I recommend reviewing the code here, not the preview.
