### PR TITLE
Redirecting setup

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,4 +11,18 @@ const withNextra = nextra({
 
 export default withNextra({
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/docs",
+        destination: "/",
+        permanent: true,
+      },
+      {
+        source: "/docs/:p*",
+        destination: "/",
+        permanent: true,
+      },
+    ];
+  },
 });


### PR DESCRIPTION
Redirecting anything like docs.cosmwasm.com/docs/* to the index (docs.cosmwasm.com/). In the old docs everything was under the `/docs` path, so such queries are most likely the old docs references.