### PR TITLE
ibc: add an example with storey

### DIFF
--- a/docs-test-gen/Cargo.lock
+++ b/docs-test-gen/Cargo.lock
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -1120,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1717,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "konst"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0964faf44d2c3e528ade7bd49c3544687cadcdee7641643469d43bd7259a5d88"
+checksum = "b65f00fb3910881e52bf0850ae2a82aea411488a557e1c02820ceaa60963dce3"
 dependencies = [
  "const_panic",
  "konst_kernel",
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "konst_kernel"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722062725c1fc0d83cc017e873aac6a2a5ff16a88edfa190bdeb8bd393fcfd97"
+checksum = "599c1232f55c72c7fc378335a3efe1c878c92720838c8e6a4fd87784ef7764de"
 dependencies = [
  "typewit",
 ]
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2557,9 +2557,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sylvia"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fbab9f40c29369b6b9c24fde7a765134f3ced8d062ade0761d1297bc65830c8"
+checksum = "8791876dcc4b99ba55a212c0f4d485bf8b695ea21335b8d2d8e7fe35a55e4e9a"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2576,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "sylvia-derive"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f0a6b79f034f6449bd198a1e9a7bb1479aaecd5cfe1ce9b70d9931df36a81c"
+checksum = "89f638b6e9383696b51431197e0bef6d4f03d638131a95f56c3269e60a03203d"
 dependencies = [
  "convert_case",
  "itertools 0.13.0",

--- a/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
+++ b/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
@@ -170,6 +170,9 @@ using the `IbcMsg::WriteAcknowledgement` message.
   Not acknowledging can lead to problems for the sender of the packet.
 </Callout>
 
+<Tabs items={['StoragePlus', 'Storey']}>
+  <Tabs.Tab>
+
 ```rust filename="ibc.rs" template="core"
 use cw_storage_plus::Map;
 
@@ -213,6 +216,61 @@ pub fn async_ack(
 
 const ACK_LATER: Map<&(u64, String), String> = Map::new("ack_later");
 ```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+```rust filename="ibc.rs" template="core"
+use cw_storey::containers::{Item, Map};
+use cw_storey::CwStorage;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn ibc_packet_receive(
+    deps: DepsMut,
+    _env: Env,
+    msg: IbcPacketReceiveMsg,
+) -> StdResult<IbcReceiveResponse> {
+    // save the data we need for the async acknowledgement in contract state
+    // note: we are just saving a String here, but you can save any information
+    // you need for the acknowledgement later
+    ACK_LATER.access(&mut CwStorage(deps.storage))
+        .entry_mut(&msg.packet.sequence)
+        .entry_mut(&msg.packet.dest.channel_id)
+        .set(&"ack str".to_string())?;
+
+    // return without an acknowledgement
+    Ok(IbcReceiveResponse::without_ack())
+}
+
+/// Called somewhere in the contract to acknowledge the packet
+pub fn async_ack(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    packet_sequence: u64,
+    channel_id: String,
+) -> StdResult<Response> {
+    // load data from contract state
+    let ack_str = ACK_LATER.access(&CwStorage(deps.storage))
+        .entry(&packet_sequence)
+        .entry(&channel_id)
+        .try_get()
+        .map_err(|_| StdError::generic_err("error accessing ACK_LATER"))?;
+
+    // send the acknowledgement
+    Ok(Response::new().add_message(IbcMsg::WriteAcknowledgement {
+        packet_sequence,
+        channel_id,
+        ack: IbcAcknowledgement::new(StdAck::success(ack_str.as_bytes())),
+    }))
+}
+
+const ACK_LATER_IX: u8 = 0;
+const ACK_LATER: Map<u64, Map<String, Item<String>>> = Map::new(ACK_LATER_IX);
+```
+
+  </Tabs.Tab>
+</Tabs>
 
 ## Receiving a packet acknowledgement
 

--- a/src/pages/storey/containers/item.mdx
+++ b/src/pages/storey/containers/item.mdx
@@ -24,7 +24,7 @@ caller can be matched against this address in execution endpoints.
 
 Here's how to store and manipulate an admin address, or any other simple data.
 
-```rust template="storage" showLineNumbers {6,10-13,15-17,20}
+```rust template="storage" showLineNumbers {5,9-12,14-16,19}
 use cw_storey::containers::Item;
 use cw_storey::CwStorage;
 
@@ -32,7 +32,6 @@ const ADMIN_IX: u8 = 0;
 
 let admin: Item<String> = Item::new(ADMIN_IX);
 let mut cw_storage = CwStorage(&mut storage);
-let mut access = admin.access(&mut cw_storage);
 
 assert_eq!(
     admin.access(&cw_storage).get().unwrap(),
@@ -49,13 +48,13 @@ assert_eq!(
 );
 ```
 
-- _line 6:_ Here we construct the `Item` facade. The constructor takes a key, which is the key the
+- _line 5:_ Here we construct the `Item` facade. The constructor takes a key, which is the key the
   data will be stored at in the underlying storage backend. See also
   [_Containers - Namespace_](.#namespace).
-- _lines 10-13_: This assertion is just to show you the `Item` is empty (`Option::None`) before it's
+- _lines 9-12_: This assertion is just to show you the `Item` is empty (`Option::None`) before it's
   initialized.
-- _lines 15-17_: Here we commit a value to storage.
-- _line 20_: Here we retrieve the value from storage.
+- _lines 14-16_: Here we commit a value to storage.
+- _line 19_: Here we retrieve the value from storage.
 
 ### Maintaining a config structure
 


### PR DESCRIPTION
`storey` now supports integer keys, so I updated this example we talked about a while back!