### PR TITLE
Remove warning about async ack being under development

### DIFF
--- a/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
+++ b/src/pages/ibc/diy-protocol/packet-lifecycle.mdx
@@ -158,10 +158,6 @@ because the failed receive can then be picked up by another relayer.
 
 ### Async acknowledgement
 
-<Callout type="warning">
-  This feature is currently under development and will be available in a future version of CosmWasm.
-</Callout>
-
 In some cases, you might want to acknowledge a packet asynchronously. This means that you receive
 the packet, but you don't immediately return an acknowledgement. One case where this is useful is if
 you need to perform some other action that requires more than one transaction to complete before you


### PR DESCRIPTION
It was released in 2.1 and no longer under development.