### PR TITLE
Default implementations for features

### DIFF
--- a/src/pages/cw-multi-test/features.mdx
+++ b/src/pages/cw-multi-test/features.mdx
@@ -15,19 +15,19 @@ you can provide your own, using `AppBuilder`'s function listed in **AppBuilder&n
 column. Names of **`MultiTest`** feature flags required to enable specific functionality are shown
 in the column **Feature&nbsp;flag**.
 
-| Feature          | Default<br/>implementation | Feature<br/>flag | AppBuilder<br/>constructor | Functionality                                      |
-| ---------------- | :------------------------: | :--------------: | -------------------------- | -------------------------------------------------- |
-| [Blocks](blocks) |          **YES**           |                  | `with_block`               | Operations on blocks.                              |
-| API              |          **YES**           |                  | `with_api`                 | Access to CosmWasm API.                            |
-| Storage          |          **YES**           |                  | `with_storage`             | Access to storage.                                 |
-| Bank             |          **YES**           |                  | `with_bank`                | Interactions with **Bank** module.                 |
-| Staking          |          **YES**           |    `staking`     | `with_staking`             | Interactions with **Staking** module.              |
-| Distribution     |          **YES**           |    `staking`     | `with_distribution`        | Interactions with **Distribution** module.         |
-| Governance       |           **NO**           |                  | `with_gov`                 | Interactions with **Governance** module.           |
-| Stargate         |           **NO**           |    `stargate`    | `with_stargate`            | Operations using `Stargate` and/or `Any` messages. |
-| Wasm             |          **YES**           |                  | `with_wasm`                | Interactions with **Wasm** module.                 |
-| Custom           |           **NO**           |                  | `new_custom`               | Operations using custom module.                    |
-| IBC              |           **NO**           |    `stargate`    | `with_ibc`                 | Inter-blockchain communication operations.         |
+| Feature          | Default<br/>implementation                                                                                       | Feature<br/>flag | AppBuilder<br/>constructor | Functionality                                      |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------- | :--------------: | -------------------------- | -------------------------------------------------- |
+| [Blocks](blocks) | [`mock_env().block{:rust}`](https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/fn.mock_env.html)           |                  | `with_block`               | Operations on blocks.                              |
+| API              | [`MockApi{:rust}`](https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockApi.html)                 |                  | `with_api`                 | Access to CosmWasm API.                            |
+| Storage          | [`MockStorage{:rust}`](https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/type.MockStorage.html)           |                  | `with_storage`             | Access to storage.                                 |
+| Bank             | [`BankKeeper{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.BankKeeper.html)                 |                  | `with_bank`                | Interactions with **Bank** module.                 |
+| Staking          | [`StakeKeeper{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.StakeKeeper.html)               |    `staking`     | `with_staking`             | Interactions with **Staking** module.              |
+| Distribution     | [`DistributionKeeper{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.DistributionKeeper.html) |    `staking`     | `with_distribution`        | Interactions with **Distribution** module.         |
+| Governance       | [`GovFailingModule{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/type.GovFailingModule.html)       |                  | `with_gov`                 | Interactions with **Governance** module.           |
+| Stargate         | [`StargateFailing{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.StargateFailing.html)       |    `stargate`    | `with_stargate`            | Operations using `Stargate` and/or `Any` messages. |
+| Wasm             | [`WasmKeeper{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.WasmKeeper.html)                 |                  | `with_wasm`                | Interactions with **Wasm** module.                 |
+| Custom           | [`FailingModule{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.FailingModule.html)           |                  | `new_custom`               | Operations using custom module.                    |
+| IBC              | [`IbcFailingModule{:rust}`](https://docs.rs/cw-multi-test/latest/cw_multi_test/type.IbcFailingModule.html)       |    `stargate`    | `with_ibc`                 | Inter-blockchain communication operations.         |
 
 ## Feature flags summary
 


### PR DESCRIPTION
Added links to default implementations of several features in MultiTest, to keep them in s single place for further references from other parts of the documentation.