### PR TITLE
Fix/err

### DIFF
--- a/src/pages/core/standard-library/cryptography.mdx
+++ b/src/pages/core/standard-library/cryptography.mdx
@@ -69,7 +69,7 @@ to keep it that way. The reasoning for that is:
   - SHA-3 family, Keccak256, cSHAKE256, BLAKE2, BLAKE3, SHA-2 family, KangarooTwelve, etc. (and this
     is just a small sample set to drive the point home)
 - Benchmarking and pricing functions (and keeping those up-to-date) correctly is a lot of work
-- We want to keep the API surface as small as possible for ease of maintainance
+- We want to keep the API surface as small as possible for ease of maintenance
 
 Keep in mind that, thanks to Wasm being our execution environment, contract execution is quite fast.
 In most cases the perceived need to move hashing into a host function is premature optimization and

--- a/src/pages/cw-multi-test/installation.mdx
+++ b/src/pages/cw-multi-test/installation.mdx
@@ -35,7 +35,7 @@ cw-multi-test = "2"
   **`MultiTest`** **IS NOT** designed to be used in production code on a real-life blockchain.
 </Callout>
 
-## Prerequisities
+## Prerequisites
 
 ### Rust and Cargo
 


### PR DESCRIPTION
# Fix: Corrected typos in documentation files

## Changes
- `src\pages\cw-multi-test\installation.mdx:38`: "Prerequisities" corrected to "Prerequisites".
- `src\pages\core\standard-library\cryptography.mdx:72`: "maintainance" corrected to "maintenance".

## Purpose
- Improved documentation accuracy and readability.
