### PR TITLE
Fix Typos in Documentation 

### DIFF
--- a/src/pages/sylvia/macros/entry-points.mdx
+++ b/src/pages/sylvia/macros/entry-points.mdx
@@ -108,7 +108,7 @@ where
 }
 ```
 
-We do that by adding parantheses after the `entry_points` macro and passing `generics` attribute
+We do that by adding parentheses after the `entry_points` macro and passing `generics` attribute
 with concrete types passed in brackets.
 
 <Callout>

--- a/src/pages/sylvia/types/communication.mdx
+++ b/src/pages/sylvia/types/communication.mdx
@@ -37,7 +37,7 @@ These methods are:
   `ExecutorBuilder` via above methods.
 </Callout>
 
-The `Remote` can be stored as a represantation of a specific contract:
+The `Remote` can be stored as a representation of a specific contract:
 
 ```rust, template="sylvia-empty"
 pub struct Contract<'a> {


### PR DESCRIPTION
# Pull Request: Fix Typos in Documentation  

## Description  
This PR fixes typos in two `.mdx` files within the project:  
- **entry-points.mdx**: Corrected the spelling of "parantheses" to "parentheses".  
- **communication.mdx**: Corrected the spelling of "represantation" to "representation".  

These changes improve the readability and professionalism of the documentation without affecting the functionality.  

## Related Issue  
No specific issue reported.  

## Changes Made  
### File: `entry-points.mdx`  
- Corrected:  
  - From: `parantheses`  
  - To: `parentheses`.  

### File: `communication.mdx`  
- Corrected:  
  - From: `represantation`  
  - To: `representation`.  

## Testing  
No functionality was affected. These are purely documentation changes.  

## Checklist  
- [x] All typos identified have been corrected.  
- [x] Documentation changes have been reviewed for additional errors.  

## Additional Notes  
These changes ensure that the project's documentation maintains a high standard of quality and accuracy.  
