### PR TITLE
Grammar Fixes in Documentation

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -10,7 +10,7 @@ are security, performance, and interoperability. It is tailored for a tight inte
 SDK and to build IBC contracts.
 
 We chose to target a Rust programming language as a smart contract development stack, as it is
-popular amonst blockchain developers and has the best Wasm compiler on the market so far. We do not
+popular amongst blockchain developers and has the best Wasm compiler on the market so far. We do not
 provide bindings to help write smart contracts in another stack that compiles to Wasm, and we don't
 support that.
 

--- a/src/pages/tutorial.mdx
+++ b/src/pages/tutorial.mdx
@@ -5,4 +5,4 @@ by step, and explain relevant topics from the easiest to the trickier ones.
 
 The point of these tutorials is not only to tell you about smart contracts API but also to show you
 how to write contracts in a clean and maintainable way. We will show you patterns that CosmWasm
-creators established and encouraged you to use.
+creators established and encourage you to use.


### PR DESCRIPTION


## Changes:

1. src/pages/index.md:
- amonst -> amongst
Reason: "Amongst" is the correct spelling meaning "in the company of"

2. src/pages/tutorial.mdx:
- encouraged -> encourage 
Reason: Verbs need parallel structure with "established" in present tense

No functional changes, only grammar improvements for better readability.