### PR TITLE
Update gas multiplier link

### DIFF
--- a/src/pages/core/architecture/gas.mdx
+++ b/src/pages/core/architecture/gas.mdx
@@ -90,6 +90,6 @@ bit (e.g. JavaScript and jq).
 [#1599]: https://github.com/CosmWasm/cosmwasm/pull/1599
 [JSON numbers]: https://www.json.org/
 [defaultgasmultiplier]:
-  https://github.com/CosmWasm/wasmd/blob/v0.19.0/x/wasm/keeper/gas_register.go#L18
+  https://github.com/CosmWasm/wasmd/blob/04cb6e5408cc54c27247b0b327dfa99769d5103c/x/wasm/types/gas_register.go#L34
 [neargas]: https://docs.near.org/concepts/protocol/gas
 [#1120]: https://github.com/CosmWasm/cosmwasm/pull/1120


### PR DESCRIPTION
The link leads to a very old wasmd version and shows a value that's not even close to the current one.