### PR TITLE
 fixes grammatical and stylistic

### DIFF
--- a/src/pages/tutorial/cw-contract/contract-creation.mdx
+++ b/src/pages/tutorial/cw-contract/contract-creation.mdx
@@ -39,7 +39,7 @@ crate-type = ["cdylib"]
 cosmwasm-std = { version = "2.1.4", features = ["staking"] }
 ```
 
-As you can see, I added a `crate-type` field for the library section. Generating the `cdylib` is
+As you can see, I added a `crate-type` field in the library section. Generating the `cdylib` is
 required to create a proper web assembly binary. The downside of this is that such a library cannot
 be used as a dependency for other Rust crates - for now, it is not needed, but later we will show
 how to approach reusing contracts as dependencies.

--- a/src/pages/tutorial/cw-contract/good-practices.mdx
+++ b/src/pages/tutorial/cw-contract/good-practices.mdx
@@ -6,8 +6,8 @@ All the relevant basics are covered. Now let's talk about some good practices.
 
 Due to Rust style, all our message variants are spelled in a
 [camel-case](https://en.wikipedia.org/wiki/CamelCase). It is standard practice, but it has a
-drawback - all messages are serialized and deserialized by serde using those variant names. The
-problem is that it is more common to use [snake cases](https://en.wikipedia.org/wiki/Snake_case) for
+drawback - all messages are serialized and deserialized by serde using these variant names. The
+problem is that it is more common to use [snake case](https://en.wikipedia.org/wiki/Snake_case) for
 field names in the JSON world. Fortunately, there is an effortless way to tell serde to change the
 casing for serialization purposes. Let's update our messages with a `#[serde]` attribute:
 

--- a/src/pages/wasmd/getting-started/proposals.mdx
+++ b/src/pages/wasmd/getting-started/proposals.mdx
@@ -56,7 +56,7 @@ wasmd tx wasm submit-proposal pin-codes $CODE_ID \
 You can pin multiple codes by providing a list of code IDs instead of just a single `code_id`. The
 `title` flag specifies the title of the proposal, which should be descriptive and concise, while the
 `summary` flag provides a brief explanation of what the proposal aims to achieve. The `deposit` flag
-indicates the amount of tokens required to submit the proposal, avoiding spam proposals submissions.
+indicates the number of tokens required to submit the proposal, avoiding spam proposals submissions.
 
 To check the details of a submitted proposal, you can query the transaction using the `txhash`
 provided in the command output. This allows you to inspect the emitted events and retrieve the


### PR DESCRIPTION
1. cw-contract/contract-creation.mdx
Old: for the library section → New: in the library section
Reason: More precise preposition usage.
2. cw-contract/good-practices.mdx
Old: using those variant names → New: using these variant names
Reason: "These" is correct for recently mentioned items.
Old: snake cases → New: snake case
Reason: "Snake case" refers to a naming convention, not multiple cases.
3. wasmd/getting-started/proposals.mdx
Old: amount of tokens → New: number of tokens
Reason: "Number" is used for countable nouns like tokens.