### PR TITLE
Fixed invalid link to Cosmos SDK

### DIFF
--- a/src/pages/core/architecture/semantics.mdx
+++ b/src/pages/core/architecture/semantics.mdx
@@ -29,7 +29,7 @@ issuer, the max issuance, etc.
 ### SDK Context
 
 Before looking at CosmWasm, we should look at the semantics enforced by the blockchain framework we
-integrate with - the [Cosmos SDK](https://v1.cosmos.network/sdk). It is based upon the
+integrate with - the [Cosmos SDK](https://docs.cosmos.network/). It is based upon the
 [Tendermint BFT](https://tendermint.com/core/) Consensus Engine. Let us first look how they process
 transactions before they arrive in CosmWasm.
 


### PR DESCRIPTION
The old link had an expired certificate.
The new one is used also in other parts of the documentation.