### PR TITLE
fix query.mdx link to execute.mdx for live docs

### DIFF
--- a/src/pages/core/entrypoints/query.mdx
+++ b/src/pages/core/entrypoints/query.mdx
@@ -6,7 +6,7 @@ import { Callout } from "nextra/components";
 
 # Query
 
-In the previous section we talked about the [`execute` endpoint](./execute) . The `query` endpoint is actually
+In the previous section we talked about the [`execute`](execute) endpoint. The `query` endpoint is actually
 pretty similar to its sibling `execute`, but with one key difference: The storage is only accessible
 immutably.
 

--- a/src/pages/core/entrypoints/query.mdx
+++ b/src/pages/core/entrypoints/query.mdx
@@ -6,9 +6,9 @@ import { Callout } from "nextra/components";
 
 # Query
 
-In the previous section we talked about the [`execute`](execute) endpoint. The `query` endpoint is actually
-pretty similar to its sibling `execute`, but with one key difference: The storage is only accessible
-immutably.
+In the previous section we talked about the [`execute`](execute) endpoint. The `query` endpoint is
+actually pretty similar to its sibling `execute`, but with one key difference: The storage is only
+accessible immutably.
 
 This means you can only _read_ from the storage but not _write_ to it.
 

--- a/src/pages/core/entrypoints/query.mdx
+++ b/src/pages/core/entrypoints/query.mdx
@@ -6,7 +6,7 @@ import { Callout } from "nextra/components";
 
 # Query
 
-In the previous section we talked about the [`execute` endpoint]. The `query` endpoint is actually
+In the previous section we talked about the [`execute` endpoint](./execute) . The `query` endpoint is actually
 pretty similar to its sibling `execute`, but with one key difference: The storage is only accessible
 immutably.
 


### PR DESCRIPTION
### Description

The link to [execute](https://github.com/CosmWasm/docs/blob/main/src/pages/core/entrypoints/execute.mdx) on https://cosmwasm.cosmos.network/core/entrypoints/query 404s on the docs because it tries opening with the `.mdx` suffix. 

### Changes

Updated the link:

```diff
- In the previous section we talked about the [`execute` endpoint]. The `query` endpoint is actually
+ In the previous section we talked about the [`execute` endpoint](./execute) . The `query` endpoint is actually
```

### Testing

Built docs and checked link works.