### PR TITLE
fix: fix syntax errors in println! and bail! macros

### DIFF
--- a/link-inspector/src/main.rs
+++ b/link-inspector/src/main.rs
@@ -10,7 +10,7 @@ static EXCLUDED_HOSTS: phf::Set<&'static str> = phf::phf_set! {
 fn check_link(link: &str) -> anyhow::Result<()> {
     let url = Url::parse(link)?;
     if EXCLUDED_HOSTS.contains(url.host_str().unwrap_or_default()) {
-        println!("⚠️ Skipping link to excluded host: {link}");
+        println!("⚠️ Skipping link to excluded host: {}", link);
         return Ok(());
     }
 
@@ -18,7 +18,8 @@ fn check_link(link: &str) -> anyhow::Result<()> {
 
     if !(200..=299).contains(&response.status()) {
         bail!(
-            "❌ Link \"{link}\" is broken (status code: {})",
+            "❌ Link \"{}\" is broken (status code: {})",
+            link,
             response.status()
         );
     }


### PR DESCRIPTION
I’ve corrected a syntax issue with variable interpolation in the `println!` and `bail!` macros. The issue was that curly braces `{}` were missing around variables in the strings, which caused compilation errors.

I’ve updated the code to follow the standard Rust syntax for string interpolation, ensuring it compiles correctly now.

Here's what was changed:

- `println!("⚠️ Skipping link to excluded host: {link}");` → `println!("⚠️ Skipping link to excluded host: {}", link);`
- `bail!("❌ Link \"{link}\" is broken (status code: {})", response.status());` → `bail!("❌ Link \"{}\" is broken (status code: {})", link, response.status());`  

Now the code should compile without any issues.