### PR TITLE
fix typographical errors in the documentation

### DIFF
--- a/src/pages/core/advanced/measuring-time.mdx
+++ b/src/pages/core/advanced/measuring-time.mdx
@@ -16,7 +16,7 @@ In each of the entrypoints, you get a parameter of the type `Env` and this struc
 `block`. The struct contained in this field has a bunch of different information about the current
 state of the blockchain you are running on.
 
-> The documentation about the `BlockInfo` struct can be [found here]
+> The documentation for the `BlockInfo` struct can be [found here]
 
 The timestamp contained in this struct can be safely used in your program as the source of the
 current time. Well, kinda. It won't be 100% matching the current time, as it is the timestamp of the
@@ -25,7 +25,7 @@ block we are currently operating on.
 But you can rely on this timestamp to have the following properties:
 
 - Consistent across the chain (every validator on the chain has the same info)
-- Monotonic (it will ever only increase or stay the same; never decrease)
+- Monotonic (it will only ever increase or stay the same; never decrease)
 
 Read more about [BFT Time] and [Proposer-Based Timestamps (PBTS)][PBTS] if you want to better
 understand where the time value comes from.

--- a/src/pages/core/architecture/events.mdx
+++ b/src/pages/core/architecture/events.mdx
@@ -13,8 +13,8 @@ metadata, allowing the contract to attach metadata to what exactly happened duri
 
 Some important details about the keys:
 
-- Whitespaces will be trimmed (i.e. removed from the begin and end)
-- Empty keys (that includes keys only consisting of whitespaces) are not allowed
+- Whitespaces will be trimmed (i.e. removed from the beginning and end)
+- Empty keys (that include keys only consisting of whitespaces) are not allowed
 - Keys _cannot_ start with an underscore (`_`). These types of keys are reserved for `wasmd`
 
 </Callout>

--- a/src/pages/cw-multi-test/app-builder.mdx
+++ b/src/pages/cw-multi-test/app-builder.mdx
@@ -108,7 +108,7 @@ assert_eq!(
 
 If you need to test contracts on your own chain that uses a specific Bech32 prefixes, you can easily
 customize the default [`MockApi{:rust}`][MockApi] behavior using the
-[`AppBuilder::with_api{:rust}`][with_api] method. An example of using `osmo` prefixes is shown in
+[`AppBuilder::with_api{:rust}`][with_api] method. An example of using `osmo` prefix is shown in
 the following code snippet.
 
 ```rust showLineNumbers copy {1,6} /with_api/ /osmo/
@@ -394,7 +394,7 @@ assert_eq!(value, app.storage().get(key).unwrap().as_slice());
   libraries such as [Storey](/storey) and [StoragePlus](/cw-storage-plus).
 </Callout>
 
-You can find additional information about storage in [Storage](storage) chapter.
+You can find additional information about storage in the [Storage](storage) chapter.
 
 ## `with_wasm`
 

--- a/src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-cosmwasm.mdx
+++ b/src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-cosmwasm.mdx
@@ -57,7 +57,7 @@ use counter::msg::{CounterExecMsg, CounterInitMsg, CounterQueryMsg, CounterRespo
 use cw_multi_test::{App, Contract, ContractWrapper, Executor, IntoAddr};
 ```
 
-## Wrapping the contact
+## Wrapping the contract
 
 ```rust copy showLineNumbers{5} filename="test_counter.rs"
 fn counter_contract() -> Box<dyn Contract<Empty>> {

--- a/src/pages/ibc/extensions/callbacks.mdx
+++ b/src/pages/ibc/extensions/callbacks.mdx
@@ -18,7 +18,7 @@ To solve this problem, the [ADR-8 specification][adr-8] was created. On the sour
 provides callbacks when an IBC packet was acknowledged or timed out. On the destination chain, it
 triggers callbacks when a packet is received.
 
-IBC Callbacks is a generalized successor of [IBC Hooks][ibc-hooks] that works not just for ICS20
+IBC Callbacks are a generalized successor of [IBC Hooks][ibc-hooks] that works not just for ICS20
 transfers, but any message that supports the required interface.
 
 [packet-lifecycle]: ../diy-protocol/packet-lifecycle


### PR DESCRIPTION
"about" → "for" — improved phrasing.
"includes" → "include" — corrected verb form.
"prefixes" → "prefix" — changed to singular for consistency.
"is" → "are" — correct verb agreement with plural.
"contact" → "contract" — corrected typographical error.
Added "the" — for grammatical correctness of the sentence.