### PR TITLE
correction documents

### DIFF
--- a/src/pages/cw-multi-test/app-builder.mdx
+++ b/src/pages/cw-multi-test/app-builder.mdx
@@ -48,7 +48,7 @@ The simplest way to create a chain using [`AppBuilder{:rust}`][AppBuilder] is by
 `default{:rust}` method. Since [`AppBuilder{:rust}`][AppBuilder] follows the principles of the
 builder pattern, you need to finalize the building process by calling the [`build{:rust}`][build]
 method with a chain initialization callback function. When no specific chain initialization is
-required you can just use provided [`no_init`](app#no_init) callback. In the following code example,
+required you can just use the provided [`no_init`](app#no_init) callback. In the following code example,
 the chain is created with default settings as described in
 [Features summary](features#features-summary).
 

--- a/src/pages/cw-multi-test/app-builder.mdx
+++ b/src/pages/cw-multi-test/app-builder.mdx
@@ -48,8 +48,8 @@ The simplest way to create a chain using [`AppBuilder{:rust}`][AppBuilder] is by
 `default{:rust}` method. Since [`AppBuilder{:rust}`][AppBuilder] follows the principles of the
 builder pattern, you need to finalize the building process by calling the [`build{:rust}`][build]
 method with a chain initialization callback function. When no specific chain initialization is
-required you can just use the provided [`no_init`](app#no_init) callback. In the following code example,
-the chain is created with default settings as described in
+required you can just use the provided [`no_init`](app#no_init) callback. In the following code
+example, the chain is created with default settings as described in
 [Features summary](features#features-summary).
 
 ```rust showLineNumbers {3} copy /default/ /build/
@@ -108,8 +108,8 @@ assert_eq!(
 
 If you need to test contracts on your own chain that uses a specific Bech32 prefixes, you can easily
 customize the default [`MockApi{:rust}`][MockApi] behavior using the
-[`AppBuilder::with_api{:rust}`][with_api] method. An example of using `osmo` prefix is shown in
-the following code snippet.
+[`AppBuilder::with_api{:rust}`][with_api] method. An example of using `osmo` prefix is shown in the
+following code snippet.
 
 ```rust showLineNumbers copy {1,6} /with_api/ /osmo/
 use cosmwasm_std::testing::MockApi;

--- a/src/pages/cw-multi-test/features.mdx
+++ b/src/pages/cw-multi-test/features.mdx
@@ -62,7 +62,7 @@ The following table summarizes feature flags supported by **`MultiTest`**.
 ## Starting point
 
 Usually, a good starting point when using **`MultiTest`** is the following dependency configuration
-in **Cargo.toml** file:
+in the **Cargo.toml** file:
 
 ```toml filename="Cargo.toml" copy
 [dependencies]

--- a/src/pages/cw-multi-test/getting-started/writing-tests.mdx
+++ b/src/pages/cw-multi-test/getting-started/writing-tests.mdx
@@ -49,7 +49,7 @@ Luckily, `clippy` reports no issues for the **counter** smart contract.
 ## Preparing the directory structure for tests
 
 Before we start writing tests, we need to set up the directories and files for the test cases. The
-final directory and file structure is shown below.
+final directory and file structure are shown below.
 
 ```ansi showLineNumbers {7-11} filename="counter (directory)"
 [34;1m.[0m

--- a/src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-cosmwasm.mdx
+++ b/src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-cosmwasm.mdx
@@ -1138,7 +1138,7 @@ Nice, you have reached 💯% code coverage.
 [0;30m }
 ```
 
-All functionalities of the **counter** smart contract has been tested, the code coverage report
+All functionalities of the **counter** smart contract have been tested, the code coverage report
 `[1;32mshines green{:ansi}`.
 
 ## Test cases put all together

--- a/src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-sylvia.mdx
+++ b/src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-sylvia.mdx
@@ -1003,7 +1003,7 @@ Nice, you have reached 💯% code coverage.
 [0;30m }
 ```
 
-All functionalities of the **counter** smart contract has been tested, and the code coverage report
+All functionalities of the **counter** smart contract have been tested, and the code coverage report
 `[1;32mshines green{:ansi}`.
 
 ## Test cases put all together


### PR DESCRIPTION
src/pages/cw-multi-test/app-builder.mdx
use provided - use the provided

src/pages/cw-multi-test/features.mdx
in **Cargo.toml** - in the **Cargo.toml**

src/pages/cw-multi-test/getting-started/writing-tests.mdx
structure is shown - structure are shown

src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-cosmwasm.mdx
contract has been - contract have been

src/pages/cw-multi-test/getting-started/writing-tests/writing-tests-sylvia.mdx
contract has been - contract have been