### PR TITLE
Fix IBC destination callback example

### DIFF
--- a/src/pages/ibc/extensions/callbacks.mdx
+++ b/src/pages/ibc/extensions/callbacks.mdx
@@ -249,7 +249,7 @@ pub fn ibc_destination_callback(
         msg.packet.src.port_id, msg.packet.src.channel_id
     );
     ensure_eq!(
-        packet_data.denom.to_string(),
+        packet_data.denom,
         ntrn_denom_on_source_chain,
         StdError::generic_err("only want to handle NTRN tokens")
     );

--- a/src/pages/ibc/extensions/callbacks.mdx
+++ b/src/pages/ibc/extensions/callbacks.mdx
@@ -202,7 +202,8 @@ This is how you can implement the `ibc_destination_callback` entrypoint:
 </Callout>
 
 ```rust template="core"
-use ibc::apps::transfer::types::packet::PacketData as TransferPacketData;
+use ibc::apps::transfer::types::proto::transfer::v2::FungibleTokenPacketData;
+use std::str::FromStr;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_destination_callback(
@@ -224,7 +225,7 @@ pub fn ibc_destination_callback(
     // but not to whom it is going, how much and what denom.
 
     // Parse the packet data to get that information:
-    let packet_data: TransferPacketData = from_json(&msg.packet.data)?;
+    let packet_data: FungibleTokenPacketData = from_json(&msg.packet.data)?;
 
     // The receiver should be a valid address on this chain.
     // Remember, we are on the destination chain.
@@ -236,17 +237,20 @@ pub fn ibc_destination_callback(
     );
 
     // We only care about this chain's native token in this example.
-    // The `packet_data.token.denom` is formatted as `{port id}/{channel id}/{denom}`,
+    // The `packet_data.denom` is formatted as `{port id}/{channel id}/{denom}`,
     // where the port id and channel id are the source chain's identifiers.
-    // Assuming we are running this on Neutron and only want to handle NTRN tokens,
-    // the denom should look like this:
-    let ntrn_denom = format!(
+    // Please note that the denom is not formatted like that when you transfer untrn
+    // from Neutron to some other chain. In that case, the denom is just the native
+    // token of the source chain (untrn).
+    // That being said, assuming we are running this on Neutron and only want to
+    // handle NTRN tokens, the denom should look like this:
+    let ntrn_denom_on_source_chain = format!(
         "{}/{}/untrn",
         msg.packet.src.port_id, msg.packet.src.channel_id
     );
     ensure_eq!(
-        packet_data.token.denom.to_string(),
-        ntrn_denom,
+        packet_data.denom.to_string(),
+        ntrn_denom_on_source_chain,
         StdError::generic_err("only want to handle NTRN tokens")
     );
 
@@ -255,7 +259,7 @@ pub fn ibc_destination_callback(
     let msg = BankMsg::Send {
         to_address: "neutron155exr8rqjrknusllpzxdfvezxr8ddpqehj9g9d".to_string(),
         // this panics if the amount is too large
-        amount: coins(packet_data.token.amount.as_ref().as_u128(), "untrn"),
+        amount: coins(u128::from_str(&packet_data.amount).unwrap(), "untrn"),
     };
 
     Ok(IbcBasicResponse::new()

--- a/src/pages/tutorial/cw-contract/funds.mdx
+++ b/src/pages/tutorial/cw-contract/funds.mdx
@@ -7,7 +7,7 @@ of cryptocurrencies. It is not the same, but crypto assets, or as we often call 
 very closely connected to the blockchain. CosmWasm has a notion of a native token. Native tokens are
 assets managed by the blockchain core instead of smart contracts. Often such assets have some
 special meaning, like being used for paying
-[gas fees](https://docs.cosmos.network/v0.52/learn/beginner/gas-fees) or
+[gas fees](https://docs.cosmos.network/v0.53/learn/beginner/gas-fees) or
 [staking](https://en.wikipedia.org/wiki/Proof_of_stake) for consensus algorithm, but can be just
 arbitrary assets.
 


### PR DESCRIPTION
I tested this in a wasmd test and the correct type to deserialize the packet data is `FungibleTokenPacketData`. This can even be seen in mintscan. For example [here](https://www.mintscan.io/osmosis/tx/D8ABE5CE08C0010E6D9BD47F1D891BB76D30E791E7FAC33BDFB5577709AA2793?sector=json):
```json
{
  "sequence": "42904",
  "source_port": "transfer",
  "source_channel": "channel-1",
  "destination_port": "transfer",
  "destination_channel": "channel-238",
  "data": "eyJhbW91bnQiOiIxMDY2NTM3ODk3NzEiLCJkZW5vbSI6InVtZW1lIiwicmVjZWl2ZXIiOiJvc21vMTZrdHhwZWpxMnd4eHk5ZmpqamZwYWY0Y2ZnZXM3djBuYXFweGx0Iiwic2VuZGVyIjoibWVtZTFyZG5xY2p3eGVoZDVtYXgyZDJremttbnF5YXh4OXFnc3pwenl6eSJ9",
  "timeout_height": {
    "revision_number": "1",
    "revision_height": "33245340"
  },
  "timeout_timestamp": "1744198145291115587"
}
```
That `data` field decoded and formatted looks like this:
```json
{
   "amount": "106653789771",
   "denom": "umeme",
   "receiver": "osmo16ktxpejq2wxxy9fjjjfpaf4cfges7v0naqpxlt",
   "sender": "meme1rdnqcjwxehd5max2d2kzkmnqyaxx9qgszpzyzy"
}
```
As you can see, it does not match the structure of [PacketData](https://docs.rs/ibc/0.57.0/ibc/apps/transfer/types/packet/struct.PacketData.html), but it does match with [FungibleTokenPacketData](https://docs.rs/ibc/0.57.0/ibc/apps/transfer/types/proto/transfer/v2/struct.FungibleTokenPacketData.html) (memo field is optional).

I also added some more explanation about the denom. 