### PR TITLE
Fix links after MockStorage type change

### DIFF
--- a/src/pages/cw-multi-test/app-builder.mdx
+++ b/src/pages/cw-multi-test/app-builder.mdx
@@ -26,7 +26,7 @@ import { Callout } from "nextra/components";
   https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.AppBuilder.html#method.with_storage
 [addr_make]:
   https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockApi.html#method.addr_make
-[MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/type.MockStorage.html
+[MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockStorage.html
 [storage]: https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.App.html#method.storage
 [storage_mut]: https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.App.html#method.storage_mut
 

--- a/src/pages/cw-multi-test/features.mdx
+++ b/src/pages/cw-multi-test/features.mdx
@@ -4,7 +4,7 @@ tags: ["multitest", "features"]
 
 [mock_env_block]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/fn.mock_env.html
 [MockApi]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockApi.html
-[MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/type.MockStorage.html
+[MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockStorage.html
 [BankKeeper]: https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.BankKeeper.html
 [StakeKeeper]: https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.StakeKeeper.html
 [DistributionKeeper]:

--- a/src/pages/cw-multi-test/storage.mdx
+++ b/src/pages/cw-multi-test/storage.mdx
@@ -2,7 +2,7 @@
 tags: ["multitest", "storage"]
 ---
 
-[MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/type.MockStorage.html
+[MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockStorage.html
 [MemoryStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.MemoryStorage.html
 [Storage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/trait.Storage.html
 [App]: https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.App.html

--- a/src/pages/cw-multi-test/storage.mdx
+++ b/src/pages/cw-multi-test/storage.mdx
@@ -3,7 +3,6 @@ tags: ["multitest", "storage"]
 ---
 
 [MockStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/testing/struct.MockStorage.html
-[MemoryStorage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/struct.MemoryStorage.html
 [Storage]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/trait.Storage.html
 [App]: https://docs.rs/cw-multi-test/latest/cw_multi_test/struct.App.html
 [get]: https://docs.rs/cosmwasm-std/latest/cosmwasm_std/trait.Storage.html#tymethod.get
@@ -69,8 +68,8 @@ storage by implementing the [Storage] trait. Only the `get{:rust}`, `set{:rust}`
 | [`range_keys{:rust}`][range_keys]     | Iterates over a set of **keys**, either forwards or backwards.            |
 | [`range_values{:rust}`][range_values] | Iterates over a set of **values**, either forwards or backwards.          |
 
-For inspiration on implementing custom storage, you can refer to [MemoryStorage] in the CosmWasm
-library. The following code stub could be a good starting point.
+For inspiration on implementing custom storage, you can refer to [`MockStorage{:rust}`][MockStorage]
+in the CosmWasm library. The following code stub could be a good starting point.
 
 ```rust showLineNumbers copy
 #[derive(Default)]


### PR DESCRIPTION
Starting with CosmWasm 3, `MockStorage` is not a `type` alias anymore. `MemoryStorage` was removed as the implementation is now in `MockStorage`.