### PR TITLE
fix: Replace find() with some() in TagFilter component

### DIFF
--- a/src/components/TagFilter.jsx
+++ b/src/components/TagFilter.jsx
@@ -9,7 +9,7 @@ export default function TagFilter() {
   const urlTags = searchParams.getAll("tag");
 
   const routes = Object.entries(tagsObj.routes)
-    .filter(([, tags]) => !urlTags.length || urlTags.find((urlTag) => tags.includes(urlTag)))
+    .filter(([, tags]) => !urlTags.length || urlTags.some((urlTag) => tags.includes(urlTag)))
     .map(([route]) => route)
     .sort();
 


### PR DESCRIPTION
Improve semantic clarity and potential performance by using Array.some() instead of Array.find() when checking for tag existence in filter condition. This change better expresses the intent of the code without altering functionality.